### PR TITLE
fixed footer for small screen devices

### DIFF
--- a/docs/.vuepress/theme/Footer.vue
+++ b/docs/.vuepress/theme/Footer.vue
@@ -56,120 +56,123 @@ export default {
 }
 </script>
 
-<style lang="css" scoped>
+<style lang="stylus" scoped>
+@import './styles/config.styl'
 
-footer {
-  width: 100%;
-  /* min-height: 30vh; */
-  height: auto;
-  background: #110d26;
-  position: relative;
-  z-index: 3000;
-  position: relative;
-  margin-top: 400px;
-  display: block;
-}
+footer
+  width 100%
+  height auto
+  background #110d26
+  position relative
+  z-index 1
+  margin-top 400px
+  display block
 
-.con-footer {
-  width: 100%;
-  height: 100vh;
-  background: rgb(255, 255, 255);
-}
-.con-copy {
-  position: absolute;
-  right: 20px;
-  bottom: 15px;
-  color: rgba(255, 255, 255, 0.2);
-  z-index: 500;
-  display: block;
-  font-size: 12px;
-}
-.con-links .lineax {
-  position: absolute;
-  /* left: 0px; */
-  top: -10px;
-  background:rgb(255, 255, 255);
-  height: 3px;
-  border-radius: 5px;
-  width: 30px;
-  /* transform: translate(100%); */
-  transition: all .3s ease;
-  color: rgb(255, 255, 255);
-  opacity: 0;
-  width: 0px;
-  left: 0px;
-  /* transform: translate(calc(100% + 7px) ); */
-}
-.lineaActiva {
-  width: 30px !important;
-  opacity: 1 !important;
-}
-.uls {
-  position: relative;
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-around;
-  width: 100%;
-  max-width: 500px;
-}
-.title {
-  color: rgb(255, 255, 255);
-  font-size: 16px;
-  padding-bottom: 15px !important;
-  font-weight: 500;
-}
-.con-links {
-  position: relative;
-  width: 40%;
-  display: flex;
-  align-items: flex-start;
-  justify-content: center;
-  z-index: 200;
-  /* padding: 30px; */
-  /* padding-top: 10px; */
-  left: 0px;
-  padding-bottom: 10px;
-  /* bottom: 50px; */
-  /* background: rgb(196, 5, 117); */
-}
-.con-links ul {
-  display: block;
-  width: 100%;
-  line-height: normal;
-  padding-left: 0px;
-  position: relative;
-  padding-left: 20px;
-}
-.con-links ul li {
-  padding: 4px;
-  list-style: none;
-}
-.con-links a {
-  cursor: pointer;
-  font-size: 13px;
-  color: rgba(255, 255, 255,.5);
-  transition: all .2s ease;
-}
-.con-links a:hover {
-  color: rgb(255, 255, 255);
-}
-.bosque {
-  position: absolute;
-  z-index: 100;
-  width: 33%;
-  right: 20%;
-  bottom: 70px;
-}
-.svg-piso {
-  transform: translate(0,-50%);
-  top: 0px;
-  display: block;
-  left: -6%;
-  position: absolute;
-  width: 112%;
-  z-index: 10;
-}
-.cls-1-piso {
-  fill: #110d26;
-}
+.con-footer
+  width 100%
+  height 100vh
+  background rgb(255, 255, 255)
+
+.con-copy
+  position absolute
+  right 20px
+  bottom 15px
+  color rgba(255, 255, 255, 0.2)
+  z-index 500
+  display block
+  font-size 12px
+
+.con-links
+  position relative
+  width 40%
+  display flex
+  align-items flex-start
+  justify-content center
+  z-index 200
+  left 0px
+  padding-bottom 10px
+  .lineax
+    position absolute
+    top -10px
+    background rgb(255, 255, 255)
+    height 3px
+    border-radius 5px
+    width 30px
+    transition all .3s ease
+    color rgb(255, 255, 255)
+    opacity 0
+    left 0px
+  ul
+    display block
+    width 100%
+    line-height normal
+    padding-left 0px
+    position relative
+    padding-left 20px
+    li
+      padding 4px
+      list-style none
+  a
+    cursor pointer
+    font-size 13px
+    color rgba(255, 255, 255,.5)
+    transition all .2s ease
+    &:hover
+      color rgb(255, 255, 255)
+
+.lineaActiva
+  width 30px !important
+  opacity 1 !important
+
+.uls
+  position relative
+  display flex
+  align-items flex-start
+  justify-content space-around
+  width 100%
+  max-width 500px
+
+.title
+  color rgb(255, 255, 255)
+  font-size 16px
+  padding-bottom 15px !important
+  font-weight 500
+
+.bosque
+  position absolute
+  z-index 100
+  width 33%
+  right 20%
+  bottom 70px
+
+.svg-piso
+  transform translate(0,-50%)
+  top 0px
+  display block
+  left -6%
+  position absolute
+  width 112%
+  z-index 10
+
+.cls-1-piso
+  fill #110d26
+
+@media (max-width: $MQMobile)
+  .con-copy
+    position static
+    text-align center
+    padding 10px 0
+
+  .con-links
+    width 100%
+
+@media (max-width: $MQMobileNarrow)
+  .uls
+    flex-wrap wrap
+    justify-content flex-start
+  .con-links ul
+    padding 0 20px
+    margin-bottom 20px
+    width 50%
 </style>
+

--- a/docs/.vuepress/theme/Home.vue
+++ b/docs/.vuepress/theme/Home.vue
@@ -133,11 +133,6 @@ export default {
 <style lang="stylus">
 @import './styles/config.styl'
 
-
-
-
-
-
 .doc-img
   position: absolute;
   transform: translate(-5%);
@@ -414,6 +409,8 @@ export default {
       padding 0 2.5rem
 
 @media (max-width: $MQMobileNarrow)
+  .heroBackgroundComponent
+    right: 0
   .home
     padding-left 1.5rem
     padding-right 1.5rem


### PR DESCRIPTION
Changes:
- Footer component is now in **stylus**. (importing media queries)
- Sidebar is now on top of the footer. (landing page)
- Positioning of ul and copyright inside the footer is now fixed.
- A little adjustment on .heroBackgroundComponent (right: 0) on mobile narrow screens.

**Before:**
[Footer without sidebar](https://user-images.githubusercontent.com/17470909/39883018-3ed6b4c6-54b8-11e8-999f-0af5483c91f0.png)
[Footer with sidebar](https://user-images.githubusercontent.com/17470909/39883019-3f2956fe-54b8-11e8-9862-9e0785400479.png)

**After:**
[Footer without sidebar](https://user-images.githubusercontent.com/17470909/39883038-5243b7c0-54b8-11e8-8629-fef248514bf3.png)
[Footer with sidebar](https://user-images.githubusercontent.com/17470909/39883039-528733b0-54b8-11e8-829f-32b8a8b7fea9.png)

Mobile Screen Devices (420px - 719px):
[Footer without sidebar](https://user-images.githubusercontent.com/17470909/39884271-e571ebea-54bb-11e8-84fd-852ec22b6008.png)
[Footer with sidebar](https://user-images.githubusercontent.com/17470909/39884272-e6e94a68-54bb-11e8-97c2-4cc5036427d0.png)
