### PR TITLE
Fix font filename for case-sensitive file systems

### DIFF
--- a/docs/.vuepress/theme/styles/theme.styl
+++ b/docs/.vuepress/theme/styles/theme.styl
@@ -30,7 +30,7 @@
 }
 @font-face {
   font-family: "MontserratThin";
-  src: url("../fonts/MONTSERRAT-EXTRALIGHT.otf");
+  src: url("../fonts/MONTSERRAT-EXTRALIGHT.OTF");
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
I'm on a case sensitive file system, so the MontserratThin font import was broken for me. I updated the file name in theme.styl so it would work on case-sensitive file systems.

![](https://i.imgur.com/PeY0Epc.png)

![](https://i.imgur.com/bkqy9Wc.png)