### PR TITLE
Fix #102 - Add vuepress as dev dependency. Import vuecode as node_module

### DIFF
--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -1,6 +1,6 @@
 import Vuesax from '../../src'
-import Vuecode from './vc/dist/vuecode.common.js'
-import './vc/dist/vuecode.css'
+import Vuecode from 'vuecode.js/dist/vuecode.common.js'
+import 'vuecode.js/dist/vuecode.css'
 import demo from './theme/demo.vue'
 import Box from './theme/box.vue'
 export default ({

--- a/docs/.vuepress/theme/Layout.vue
+++ b/docs/.vuepress/theme/Layout.vue
@@ -31,8 +31,7 @@ import Home from './Home.vue'
 import Navbar from './Navbar.vue'
 import Page from './Page.vue'
 import Sidebar from './Sidebar.vue'
-import { pathToComponentName } from '@app/util'
-import { resolveSidebarItems } from './util'
+import { resolveSidebarItems, pathToComponentName } from './util'
 import './icons/font/flaticon.css'
 export default {
   components: { Home, Page, Sidebar, Navbar },

--- a/docs/.vuepress/theme/util.js
+++ b/docs/.vuepress/theme/util.js
@@ -1,3 +1,5 @@
+import { findPageForPath } from '@app/util'
+
 export const hashRE = /#.*$/
 export const extRE = /\.(md|html)$/
 export const endingSlashRE = /\/$/
@@ -208,4 +210,9 @@ function resolveItem (item, pages, base, isNested) {
       collapsable: item.collapsable !== false
     }
   }
+}
+
+export function pathToComponentName (pages, path) {
+  const page = findPageForPath(pages, path)
+  return page && page.key
 }

--- a/package.json
+++ b/package.json
@@ -43,11 +43,14 @@
     "vuecode.js": "0.0.27"
   },
   "devDependencies": {
+    "@babel/core": "^7.0.0-beta.49",
     "@vue/cli-plugin-babel": "^3.0.0-beta.6",
     "@vue/cli-plugin-eslint": "^3.0.0-beta.6",
     "@vue/cli-service": "^3.0.0-beta.6",
     "copy-webpack-plugin": "^4.5.1",
-    "vue-template-compiler": "^2.5.13"
+    "vue-template-compiler": "^2.5.13",
+    "vuepress": "^0.10.1",
+    "webpack": "^4.12.0"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
This fixes #102 (I was having the same issue when trying to run the vuesax docs locally).

1. In `docs/.vuepress/enhanceApp.js` Instead of importing vuecode.common.js from `./vc`, import it directly from node_modules

`import Vuecode from './vc/dist/vuecode.common.js'` -> `import Vuecode from 'vuecode.js/dist/vuecode.common.js'`

`import './vc/dist/vuecode.css'` -> `import 'vuecode.js/dist/vuecode.css'`

2. vuepress recently removed the `pathToComponentName` function from utils, so I added the code to `./utils`, which leads to why I added vuepress as a dev dependency.

https://github.com/vuejs/vuepress/blob/master/lib/app/util.js -> now missing `pathToComponentName`

3. Add vuepress as a dev dependency.

Instead of requiring contributors to install vuepress globally, as a dev dependency, you can be sure everyone is using the same version. The build script will still work, it now just looks at the vuepress in `node_modules` instead of the globally installed one.
