### PR TITLE
Add support to FontAwesome font library in vs-input component

### DIFF
--- a/docs/.vuepress/components/Demos/Input/Icons.vue
+++ b/docs/.vuepress/components/Demos/Input/Icons.vue
@@ -6,6 +6,8 @@
     <vs-input vs-icon-after="true"  vs-icon="shopping_cart" vs-label-placeholder="Label-placeholder" v-model="value4"/>
     <vs-input disabled="true" vs-icon="error_outline" vs-label-placeholder="icon-disabled" v-model="value5"/>
     <vs-input vs-icon-after="true" disabled="true" vs-icon="email" vs-label-placeholder="icon-disabled" v-model="value6"/>
+    <vs-input vs-icon="fa-user" vs-icon-pack="fas" vs-placeholder="FontAwesome" v-model="value7"/>
+    <vs-input vs-icon-after="true" vs-icon="fa-user" vs-icon-pack="fas" vs-placeholder="FontAwesome" v-model="value8"/>
   </div>
 </template>
 
@@ -18,7 +20,9 @@ export default {
       value3:'',
       value4:'',
       value5:'',
-      value6:''
+      value6:'',
+      value7:'',
+      value8: ''
     }
   }
 }

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -4,6 +4,7 @@ module.exports = {
   head: [
     ['title',{},'hola'],
     ['link', { rel: 'icon', href: `/favicon-vuesax.png` }],
+    ['link', { rel: 'stylesheet', href: `https://use.fontawesome.com/releases/v5.0.13/css/all.css` }],
   ],
   docsDir: 'docs',
   host:'localhost',

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -203,6 +203,9 @@ The input can have icons the property to add them is `vs-icon` and we can also m
 
 ::: tip
 Vuesax use the **Google Material Icons** font library. For a list of all available icons, visit the official [Material Icons page](https://material.io/icons/).
+
+FontAwesome and other fonts library are supported. Simply use the ` vs-icon-pack` with `fa` or `fas`. You still need to include the Font Awesome icons in your project.
+
 :::
 
 <vuecode md>
@@ -211,7 +214,7 @@ Vuesax use the **Google Material Icons** font library. For a list of all availab
 </div>
 <div slot="code">
 
-```html{4,7}
+```html
 <template lang="html">
   <div class="centerx">
     <vs-input
@@ -224,6 +227,8 @@ Vuesax use the **Google Material Icons** font library. For a list of all availab
     <vs-input vs-icon-after="true"  vs-icon="shopping_cart" vs-label-placeholder="Label-placeholder" v-model="value4"/>
     <vs-input disabled="true" vs-icon="error_outline" vs-label-placeholder="icon-disabled" v-model="value5"/>
     <vs-input vs-icon-after="true" disabled="true" vs-icon="email" vs-label-placeholder="icon-disabled" v-model="value6"/>
+    <vs-input vs-icon="fa-user" vs-icon-pack="fas" vs-placeholder="FontAwesome" v-model="value7"/>
+    <vs-input vs-icon-after="true" vs-icon="fa-user" vs-icon-pack="fas" vs-placeholder="FontAwesome" v-model="value7"/>
   </div>
 </template>
 
@@ -236,7 +241,8 @@ export default {
       value3:'',
       value4:'',
       value5:'',
-      value6:''
+      value6:'',
+      value7:''
     }
   }
 }

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -25,6 +25,11 @@ API:
    parameters: Icon Material
    description: Element icon.
    default: null
+ - name: vs-icon-pack
+   type: String
+   parameters: Icon Pack
+   description: Icon Pack Description. If not use, vs-icon will base in Material Icons. 
+   default: null
  - name: vs-icon-after
    type: String
    parameters: null

--- a/src/components/vsInput/vsInput.vue
+++ b/src/components/vsInput/vsInput.vue
@@ -20,7 +20,10 @@
     <span v-if="!vsLabelPlaceholder" @click="$refs.inputx.focus()" :class="{'noPlaceholder':value?(value.length>0 || typeof value === 'number'):false?true:focusx}" class="placeholder">{{vsPlaceholder}}</span>
     <span :style="{'color':focusx?backgroundx:'rgba(0, 0, 0, 0.30)'}" v-if="vsLabelPlaceholder" @click="$refs.inputx.focus()" :class="{'noPlaceholderLabel':value.length>0?true:focusx}" class="placeholder">{{vsLabelPlaceholder}}</span>
 
-    <span v-if="vsIcon" class="iconx"><i class="material-icons">{{vsIcon}}</i></span>
+    <span v-if="vsIcon" class="iconx">
+      <i v-if="vsIconPack == null" class="material-icons">{{vsIcon}}</i>
+      <i v-else :class="[vsIconPack, vsIcon]"></i>
+    </span>
 
     <div :title="validar=='input-mal'?vsDangerText:null" class="icon-validar-mal">
       <i class="material-icons">error</i>
@@ -64,6 +67,7 @@ export default {
     'vsLabel',
     'disabled',
     'vsIcon',
+    'vsIconPack',
     'vsIconAfter',
     'vsColor',
     'vsType',


### PR DESCRIPTION
Added to vs-input component support to use FontAwesome font library or others similary.

Example:

`<vs-input vs-icon="fa-user" vs-icon-pack="fas" vs-placeholder="FontAwesome" v-model="value7"/>`