### PR TITLE
Fix/button sizes and spacing

### DIFF
--- a/src/components/vsButton/vsButton.vue
+++ b/src/components/vsButton/vsButton.vue
@@ -125,7 +125,7 @@ export default {
         let color = _color.getColor(this.vsColor,1)
         return {
           background: _color.getColor(this.vsColor,1),
-          borderBottom: `3px solid ${_color.darken(color,-0.4)}`
+          boxShadow: `0 3px 0 0 ${_color.darken(color,-0.4)}`
         }
       }
     },
@@ -302,7 +302,7 @@ $vs-types := filled, border
 &.vs-button-relief
   &:active
     transform: translate(0,3px);
-    border-bottom-width: 0px !important;
+    box-shadow: none !important;
 
 &.includeIcon
   display: flex;
@@ -352,5 +352,5 @@ for colorx, i in $vs-colors
       if colorx == 'dark' {
         background: lighten($vs-colors[colorx], 20%)
       }
-      border-bottom: 3px solid darken($vs-colors[colorx],30%)
+      box-shadow: 0 3px 0 0 darken($vs-colors[colorx],30%)
 </style>

--- a/src/components/vsButton/vsButton.vue
+++ b/src/components/vsButton/vsButton.vue
@@ -125,7 +125,7 @@ export default {
         let color = _color.getColor(this.vsColor,1)
         return {
           background: _color.getColor(this.vsColor,1),
-          boxShadow: `0 3px 0 0 ${_color.darken(color,-0.4)}`
+          borderBottom: `3px solid ${_color.darken(color,-0.4)}`
         }
       }
     },
@@ -240,7 +240,7 @@ $vs-types := filled, border
 
 .vs-button
   transition: all .2s ease;
-  padding: 9px;
+  padding: 10px;
   border: 0px;
   border-radius: 5px;
   cursor: pointer;
@@ -268,6 +268,8 @@ $vs-types := filled, border
     color: inherit
     display: inline-block;
     transition: all .2s ease;
+&.vs-button-border
+  padding: 9px;
 &.vs-button-border,&.vs-button-flat
   &.isActive
     .vs-button-text,.vs-button-icon
@@ -278,6 +280,7 @@ $vs-types := filled, border
     box-shadow: 0px 9px 28px -9px
 
 &.vs-button-line
+  padding: 9px 10px;
   border-radius: 0px
   overflow: visible;
   border-style: solid;
@@ -300,9 +303,10 @@ $vs-types := filled, border
     box-shadow: 0px 8px 25px -8px rgb(170, 170, 170)
 
 &.vs-button-relief
+  padding: 10px;
   &:active
     transform: translate(0,3px);
-    box-shadow: none !important;
+    border-bottom-width: 0px !important;
 
 &.includeIcon
   display: flex;
@@ -352,5 +356,5 @@ for colorx, i in $vs-colors
       if colorx == 'dark' {
         background: lighten($vs-colors[colorx], 20%)
       }
-      box-shadow: 0 3px 0 0 darken($vs-colors[colorx],30%)
+      border-bottom: 3px solid darken($vs-colors[colorx],30%)
 </style>


### PR DESCRIPTION
When clicking the relief button, every html block below would rise 3px because of the border width change. Now, using box-shadow, instead of the border-bottom, it works smoothier.

Also, the buttons are now always the same size of the input component.