### PR TITLE
fix: relief button now does not set bottom spacing/border

### DIFF
--- a/src/components/vsButton/vsButton.vue
+++ b/src/components/vsButton/vsButton.vue
@@ -128,7 +128,7 @@ export default {
         let color = _color.getColor(this.vsColor,1)
         return {
           background: _color.getColor(this.vsColor,1),
-          borderBottom: `3px solid ${_color.darken(color,-0.4)}`
+          boxShadow: `0 3px 0 0 ${_color.darken(color,-0.4)}`
         }
       }
     },
@@ -309,7 +309,7 @@ $vs-types := filled, border
   padding: 10px;
   &:active
     transform: translate(0,3px);
-    border-bottom-width: 0px !important;
+    box-shadow: none !important;
 
 &.includeIcon
   display: flex;
@@ -361,5 +361,5 @@ for colorx, i in $vs-colors
       if colorx == 'dark' {
         background: lighten($vs-colors[colorx], 20%)
       }
-      border-bottom: 3px solid darken($vs-colors[colorx],30%)
+      box-shadow: 0 3px 0 0 darken($vs-colors[colorx],30%)
 </style>


### PR DESCRIPTION
On my previous PR I accidentally removed these changes for the relief button. They're necessary for better spacing between relief buttons and any block located to the bottom of them.