### PR TITLE
Fix text delay 3s to 2s

### DIFF
--- a/docs/.vuepress/components/Demos/Tooltip/Delay.vue
+++ b/docs/.vuepress/components/Demos/Tooltip/Delay.vue
@@ -6,7 +6,7 @@
     <vs-tooltip delay=".5s" text="Tooltip delay 0.5s">
       <vs-button>Delay 0.5s</vs-button>
     </vs-tooltip>
-    <vs-tooltip delay="2s" text="Tooltip delay 3s">
+    <vs-tooltip delay="2s" text="Tooltip delay 2s">
       <vs-button>Delay 2s</vs-button>
     </vs-tooltip>
   </div>

--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -137,7 +137,7 @@ You can change the delay in appearing the tooltip with the property `delay`.
     <vs-tooltip delay=".5s" text="Tooltip delay 0.5s">
       <vs-button>Delay 0.5s</vs-button>
     </vs-tooltip>
-    <vs-tooltip delay="2s" text="Tooltip delay 3s">
+    <vs-tooltip delay="2s" text="Tooltip delay 2s">
       <vs-button>Delay 2s</vs-button>
     </vs-tooltip>
   </div>


### PR DESCRIPTION
Correcting the display of seconds on hover and in the code.

![screenshot_1](https://user-images.githubusercontent.com/14747569/43363947-fd90e3e8-9318-11e8-8576-ce3afbfd822c.png)