### PR TITLE
Use flex by default for rows

### DIFF
--- a/src/layout/vsRow/vsRow.vue
+++ b/src/layout/vsRow/vsRow.vue
@@ -4,6 +4,7 @@
       'align-items':vsAlign,
       'justify-content':vsJustify,
       'display':vsType,
+      'overflow': vsType === 'block' ? 'hidden' : null,
       'width':vsW*100/12+'%'}"
     class="vs-row">
     <slot/>
@@ -11,33 +12,32 @@
 </template>
 
 <script>
-export default {
-  name:'VsRow',
-  props:{
-    vsType:{
-      default:'block',
-      type:String,
-    },
-    vsW:{
-      type:[Number,String],
-      default:12,
-    },
-    vsJustify:{
-      type:String,
-      default:null,
-    },
-    vsAlign:{
-      type:String,
-      default:null,
-    },
+  export default {
+    name: 'VsRow',
+    props: {
+      vsType: {
+        default: 'flex',
+        type: String,
+      },
+      vsW: {
+        type: [Number, String],
+        default: 12,
+      },
+      vsJustify: {
+        type: String,
+        default: null,
+      },
+      vsAlign: {
+        type: String,
+        default: null,
+      },
+    }
   }
-}
 </script>
 
 <style lang="css">
-.vs-row {
-  clear: both;
-  overflow: hidden;
-  flex-flow: wrap;
-}
+  .vs-row {
+    clear: both;
+    flex-flow: wrap;
+  }
 </style>


### PR DESCRIPTION
* Remove overflow hidden for flex (as it blocks shadow and gradient button edge when on-hovering)