### PR TITLE
Add material Icons link to Getting Started page

### DIFF
--- a/docs/vuesax/README.md
+++ b/docs/vuesax/README.md
@@ -65,6 +65,9 @@ Then Import it to your project:
 import 'material-icons/iconfont/material-icons.css';
 ```
 
+Also, please check the available icons from the following.
+[https://material.io/tools/icons/](https://material.io/tools/icons/)
+
 </box>
 
 <box>


### PR DESCRIPTION
## About

Add Material Design icons page link to Gettting Started page.
https://material.io/tools/icons/?style=baseline