### PR TITLE
Add `vs-pos` prop on sidebar

### DIFF
--- a/docs/.vuepress/components/Demos/SideBar/Right.vue
+++ b/docs/.vuepress/components/Demos/SideBar/Right.vue
@@ -1,0 +1,39 @@
+<template lang="html">
+  <div id="parentx4" class="con-example-sidebar">
+    <vs-button @click="active=!active" vs-type="filled">Open Sidebar</vs-button>
+    <vs-sidebar vs-parent="#parentx4" :vs-active.sync="active" vs-pos="right">
+
+      <vs-sidebar-item @click="actives=1" :vs-active="actives==1" vs-icon="question_answer">
+         Dashboard
+      </vs-sidebar-item>
+      <vs-sidebar-item @click="actives=2" :vs-active="actives==2" vs-icon="gavel">
+         History
+      </vs-sidebar-item>
+      <vs-sidebar-item @click="actives=3" :vs-active="actives==3" vs-icon="verified_user">
+         Configurations
+      </vs-sidebar-item>
+      <vs-sidebar-item @click="actives=4" :vs-active="actives==4" vs-icon="account_box">
+         Perfile
+      </vs-sidebar-item>
+      <vs-sidebar-item @click="actives=5" :vs-active="actives==5" vs-icon="card_giftcard">
+         card
+      </vs-sidebar-item>
+
+    </vs-sidebar>
+  </div>
+</template>
+
+<script>
+export default {
+  data:()=>({
+    active:false,
+    actives:2,
+  })
+}
+</script>
+
+<style lang="stylus">
+.con-example-sidebar
+  height: 500px;
+  position: relative;
+</style>

--- a/docs/components/sideBar.md
+++ b/docs/components/sideBar.md
@@ -30,6 +30,11 @@ API:
    parameters: null
    description: Determines if the group of links is open.
    default: false
+ - name: vs-pos
+   type: String
+   parameters: null
+   description: Determines where the sidebar should be opened from.
+   default: left
  - name: vs-reduce-expand
    type: Boolean
    parameters: null
@@ -353,6 +358,69 @@ export default {
 <style lang="stylus">
 .con-example-sidebar
   height: 500px;
+</style>
+```
+
+</div>
+</vuecode>
+</box>
+
+<box>
+
+## Open on the right
+
+You can also choose where you'd like the sidebar to appear, right or left? By default, a sidebar will be located on
+the left of the screen but sometimes, a right-screened sidebar is really useful!
+
+:::warning
+A `static` sidebar will not appear on the right.
+:::
+
+<vuecode md>
+<div slot="demo">
+  <Demos-SideBar-Right />
+</div>
+<div slot="code">
+
+```html
+<template lang="html">
+  <div id="parentx4" class="con-example-sidebar">
+    <vs-button @click="active=!active" vs-type="filled">Open Sidebar</vs-button>
+    <vs-sidebar vs-parent="#parentx4" :vs-active.sync="active" vs-pos="right">
+
+      <vs-sidebar-item @click="actives=1" :vs-active="actives==1" vs-icon="question_answer">
+         Dashboard
+      </vs-sidebar-item>
+      <vs-sidebar-item @click="actives=2" :vs-active="actives==2" vs-icon="gavel">
+         History
+      </vs-sidebar-item>
+      <vs-sidebar-item @click="actives=3" :vs-active="actives==3" vs-icon="verified_user">
+         Configurations
+      </vs-sidebar-item>
+      <vs-sidebar-item @click="actives=4" :vs-active="actives==4" vs-icon="account_box">
+         Perfile
+      </vs-sidebar-item>
+      <vs-sidebar-item @click="actives=5" :vs-active="actives==5" vs-icon="card_giftcard">
+         card
+      </vs-sidebar-item>
+
+    </vs-sidebar>
+  </div>
+</template>
+
+<script>
+export default {
+  data:()=>({
+    active:false,
+    actives:2,
+  })
+}
+</script>
+
+<style lang="stylus">
+.con-example-sidebar
+  height: 500px;
+  position: relative;
 </style>
 ```
 

--- a/src/components/vsSelect/vsSelect.vue
+++ b/src/components/vsSelect/vsSelect.vue
@@ -8,8 +8,8 @@
       'input-select-validate-warning':vsWarning}"
     class="con-select">
     <label
-      ref="inputSelectLabel"
       v-if="vsLabel"
+      ref="inputSelectLabel"
       class="input-select-label"
       for="">{{ vsLabel }}</label>
     <div class="input-select-con">

--- a/src/components/vsSideBar/vsSideBar.vue
+++ b/src/components/vsSideBar/vsSideBar.vue
@@ -189,140 +189,152 @@ export default {
   transform translate(100%) !important
 
 .con-sidebar
-  transition: all .25s ;
-  height: 100%;
-  position: absolute;
-  left: 0px;
-  top: 0px;
-  width: 100%;
-  z-index: 10000;
-  overflow: hidden;
+  transition all .25s
+  height 100%
+  position absolute
+  left 0px
+  top 0px
+  width 100%
+  z-index 10000
+  overflow hidden
+
   .expand-reduce
-    display: flex;
-    justify-content: flex-end;
-    position: relative;
-    // background: rgb(254, 57, 194);
-    width: 100%;
+    display flex
+    justify-content flex-end
+    position relative
+    // background rgb(254, 57, 194)
+    width 100%
+
     i
-      position: relative;
-      display: block;
-      padding: 7px;
-      cursor: pointer;
+      position relative
+      display block
+      padding 7px
+      cursor pointer
+
   &.body-sidebar
-    position: fixed !important;
+    position fixed !important
+
   .con-darkx
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    left: 0px;
-    top: 0px;
-    opacity: 1;
-    background: rgba(3, 7, 15,.2)
-    // background-image: linear-gradient(200deg, rgba(0, 0, 0, 0.01) 25%, rgba(0, 0, 0, 0.4) 100%);
+    position absolute
+    width 100%
+    height 100%
+    left 0px
+    top 0px
+    opacity 1
+    background rgba(3, 7, 15,.2)
+
   .vs-sidebar
-    width: calc(100% - 20px);
-    max-width: 270px;
-    height: 100%;
-    position: absolute;
-    top: 0px;
-    box-shadow: 5px 0px 20px 0px rgba(0, 0, 0, 0.1);
-    background: rgb(255, 255, 255);
-    display: block;
-    transform: translate(0);
-    transition: all .3s ease;
+    width calc(100% - 20px)
+    max-width 270px
+    height 100%
+    position absolute
+    top 0px
+    box-shadow 5px 0px 20px 0px rgba(0, 0, 0, 0.1)
+    background rgb(255, 255, 255)
+    display block
+    transform translate(0)
+    transition all .3s ease
+
     .ulx
-      padding: 0px;
-      overflow: auto;
-      height: 100%;
+      padding 0px
+      overflow auto
+      height 100%
+
     header
-      padding-top: 20px;
+      padding-top 20px
 
 
 &.reducex
+
   .expand-reduce
-    width: 100%;
-    align-items: center;
-    justify-content: center;
-  // background: rgb(24, 198, 180) !important;
-  max-width: 60px !important;
+    width 100%
+    align-items center
+    justify-content center
+  // background rgb(24, 198, 180) !important
+  max-width 60px !important
+
   li
-    width: 45px !important;
-    height: 45px !important;
-    border-radius: 10px;
-    // overflow: hidden;
-    margin-left: 7.5px;
-    margin-top: 5px !important;
-    margin-bottom: 5px !important;
-    background: rgb(255, 255, 255);
-    padding-left: 0px !important
-    box-shadow: 0px 8px 30px 4px rgba(0, 0, 0, 0.08)
+    width 45px !important
+    height 45px !important
+    border-radius 10px
+    // overflow hidden
+    margin-left 7.5px
+    margin-top 5px !important
+    margin-bottom 5px !important
+    background rgb(255, 255, 255)
+    padding-left 0px !important
+    box-shadow 0px 8px 30px 4px rgba(0, 0, 0, 0.08)
+
     &.active-item
-      // background: rgb(114, 168, 12);
       .vs-tagx
-        background: rgb(255, 255, 255)
+        background rgb(255, 255, 255)
+
       a
-        color: rgb(255, 255, 255) !important;
+        color rgb(255, 255, 255) !important
+
       &:after
-        border-radius: 10px;
-        width: 4px;
-        display: none;
-        height: 30px !important;
+        border-radius 10px
+        width 4px
+        display none
+        height 30px !important
+
     .vs-tagx
-      width: 7px !important;
-      height: 7px !important;
-      right: 5px;
-      padding: 0px !important;
-      overflow: hidden;
-      color: rgba(255, 255, 255,0) !important
-      top: 5px !important;
-      position: absolute !important;
-      transform: translate(0) !important;
+      width 7px !important
+      height 7px !important
+      right 5px
+      padding 0px !important
+      overflow hidden
+      color rgba(255, 255, 255,0) !important
+      top 5px !important
+      position absolute !important
+      transform translate(0) !important
+
     a
-      padding: 0px !important
-      position: absolute;
-      width: 100%;
-      height: 100%;
-      display: flex;
-      align-items: center !important;
-      justify-content: center !important;
-      margin: 0px !important
+      padding 0px !important
+      position absolute
+      width 100%
+      height 100%
+      display flex
+      align-items center !important
+      justify-content center !important
+      margin 0px !important
       .material-icons
-        margin-right: 0px !important;
+        margin-right 0px !important
     .only-reduse
-      display: block !important;
+      display block !important
     .textx_span
-      display: none;
+      display none
     .icon-arrowx
-      font-size: 0.9375em !important;
-      top: 9px !important;
-      right: 1px !important;
-      margin-right: 0px !important;
-      // transform: translate(0) !important;
+      font-size 0.9375em !important
+      top 9px !important
+      right 1px !important
+      margin-right 0px !important
+
   .labelx
-    padding: 0px !important;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    padding 0px !important
+    display flex
+    align-items center
+    justify-content center
     i
-      margin-right: 0px !important;
-  // max-width: 55px !important
+      margin-right 0px !important
+
 
 @css {
   .reducex .active-item {
-    background: rgb(var(--primary))
+    background: rgb(var(--primary));
   }
 }
 
 
 // static
 .vsStatic
-  position: relative;
-  display: block;
-  width: 100%;
-  width: 280px;
+  position relative
+  display block
+  width 100%
+  width 280px
   .vs-sidebar
-    box-sizing: border-box;
-    border-right: 1px solid rgba(0, 0, 0, 0.1)
-    width: 100% !important;
+    box-sizing border-box
+    border-right 1px solid rgba(0, 0, 0, 0.1)
+    width 100% !important
 
 </style>

--- a/src/components/vsSideBar/vsSideBar.vue
+++ b/src/components/vsSideBar/vsSideBar.vue
@@ -1,18 +1,30 @@
 <template lang="html">
-  <transition name="sidebarx">
-    <div
-      v-show="vsStatic?true:vsActive"
-      ref="considebar"
-      :class="{'vsStatic':vsStatic,'body-sidebar':vsParent=='body'}"
-      class="vs-component con-sidebar">
+  <div
+    v-show="vsStatic || vsActive"
+    ref="considebar"
+    :class="{'vsStatic':vsStatic,'body-sidebar':vsParent=='body'}"
+    class="vs-component con-sidebar">
+
+    <!-- Overlay -->
+    <transition name="vs-sidebar-overlay">
       <div
-        v-if="vsBackgroundHidden?false:!vsStatic"
+        v-show="vsActive && (!vsBackgroundHidden || !vsStatic)"
         class="con-darkx"
         @click="clickOut()"/>
-      <!-- :style="{'color':vsColor?/[#()]/.test(vsColor)?vsColor:`rgba(var(--${vsColor}),1)`:'rgb(var(--primary))'}" -->
+    </transition>
+
+    <!-- Core -->
+    <transition
+      :leave-to-class="`vs-sidebar-core-${vsPos}`"
+      :enter-class="`vs-sidebar-core-${vsPos}`"
+      appear
+      name="vs-sidebar-core">
       <div
+        v-show="vsStatic || vsActive"
         :class="{'reducex':reduce}"
-        class="vs-sidebar">
+        :style="posStyle"
+        class="vs-sidebar"
+      >
         <div
           v-if="vsReduceExpand"
           class="expand-reduce">
@@ -37,8 +49,8 @@
           <slot name="footer"/>
         </footer>
       </div>
-    </div>
-  </transition>
+    </transition>
+  </div>
 </template>
 
 <script>
@@ -81,11 +93,22 @@ export default {
     vsBackgroundHidden:{
       default:false,
       type:Boolean
+    },
+    vsPos:{
+      default:'left',
+      type:String
     }
   },
   data:()=>({
     reduce:false
   }),
+  computed:{
+    posStyle(){
+      return {
+        [this.vsPos]: '0px'
+      }
+    }
+  },
   watch:{
     vsReduce(){
       this.reduce = this.vsReduce
@@ -114,8 +137,6 @@ export default {
       document.querySelector(this.vsParent).addEventListener("touchend",this.onTouchEnd)
       this.insertBody()
     })
-
-
   },
   methods:{
     onTouchStart (e) {
@@ -155,30 +176,17 @@ export default {
 <style lang="stylus">
 // vars
 
+.vs-sidebar-overlay-enter, .vs-sidebar-overlay-leave-to
+  opacity 0 !important
 
-.sidebarx-enter-active , .sidebarx-leave-active {
-  transition: all .25s;
-}
-.sidebarx-enter , .sidebarx-leave-to /* .sidebarx-leave-active below version 2.1.8 */ {
-  // transition: all .5s ;
-  // transform: translate(-100%) !important;
-}
+.vs-sidebar-overlay-enter-active, .vs-sidebar-overlay-leave-active
+  transition opacity .25s
 
-.sidebarx-enter-active .vs-sidebar, .sidebarx-leave-active .vs-sidebar{
-  transition: all .25s;
-}
-.sidebarx-enter .vs-sidebar, .sidebarx-leave-to .vs-sidebar/* .sidebarx-leave-active below version 2.1.8 */ {
-  // transition: all .5s ;
-  transform: translate(-100%) !important;
-}
+.vs-sidebar-core-left
+  transform translate(-100%) !important
 
-.sidebarx-enter-active .con-darkx, .sidebarx-leave-active .con-darkx{
-  transition: all .25s ease !important;
-}
-.sidebarx-enter .con-darkx, .sidebarx-leave-to .con-darkx/* .sidebarx-leave-active below version 2.1.8 */ {
-  // transition: all .5s ;
-  opacity: 0 !important;
-}
+.vs-sidebar-core-right
+  transform translate(100%) !important
 
 .con-sidebar
   transition: all .25s ;
@@ -216,7 +224,6 @@ export default {
     max-width: 270px;
     height: 100%;
     position: absolute;
-    left: 0px;
     top: 0px;
     box-shadow: 5px 0px 20px 0px rgba(0, 0, 0, 0.1);
     background: rgb(255, 255, 255);


### PR DESCRIPTION
Hello,

So I added a `vs-pos` prop on the `vsSideBar` component so that it can appear on the right of the screen instead of the left on demand.

I added an example on the doc too.

`vs-pos` shall be one of the following values:
* `'right'`
* `'left'`

It defaults to `left` so nothing changed for the already implemented sidebars.

Also, I went ahead and reformat the style of `sideBar.vue` to make full use of `stylus`.

I also isolated the overlay from the "real" component so that it is easier to manipulate.

Please, let me know if it helps and if I need to do some more!