### PR TITLE
Change vsUpload headers prop type to Object

### DIFF
--- a/docs/components/upload.md
+++ b/docs/components/upload.md
@@ -15,13 +15,8 @@ API:
    parameters: null
    description: Limit the number of files that can be added.
    default: null
- - name: limit
-   type: Number
-   parameters: null
-   description: Limit the number of files that can be added.
-   default: null
  - name: headers
-   type: String
+   type: Object
    parameters: null
    description: Change the header of the request to the server.
    default: null

--- a/src/components/vsUpload/vsUpload.vue
+++ b/src/components/vsUpload/vsUpload.vue
@@ -131,7 +131,7 @@
       },
       headers:{
         default:null,
-        type:String
+        type:Object
       },
       automatic:{
         default: false,


### PR DESCRIPTION
The prop 'headers' in the vsUpload component has a type of String yet, it is being processed in the component as an Object.

``` 
const headers = this.headers || {};
for (let head in headers) {
  if (headers.hasOwnProperty(head) && headers[head] !== null) {
    xhr.setRequestHeader(head, headers[head]);
  }
}
```
It's a small change but, just to avoid confusion and the warning message in the console