### PR TITLE
Added props: (data, showUploadButton) to the vsUpload component

### DIFF
--- a/docs/components/upload.md
+++ b/docs/components/upload.md
@@ -60,6 +60,11 @@ API:
    parameters:
    description: It determines if the shipment is automatic when making a change of value.
    default: false
+ - name: show-upload-button
+   type: Boolean
+   parameters:
+   description: It determines whether to show the upload button or not.
+   default: true
 ---
 
 # Upload **- ssr**

--- a/docs/components/upload.md
+++ b/docs/components/upload.md
@@ -20,6 +20,11 @@ API:
    parameters: null
    description: Change the header of the request to the server.
    default: null
+ - name: data
+   type: Object
+   parameters: null
+   description: Appends data to the form.
+   default: null
  - name: fileName
    type: String
    parameters: null

--- a/src/components/vsUpload/vsUpload.vue
+++ b/src/components/vsUpload/vsUpload.vue
@@ -27,6 +27,7 @@
 
       </span>
       <button
+        v-if="showUploadButton"
         type="button"
         title="Upload"
         class="btn-upload-all"
@@ -60,6 +61,7 @@
             </i>
           </button>
           <button
+            v-if="showUploadButton"
             :class="{
               'on-progress':img.percent,
               'ready-progress':img.percent >= 100
@@ -139,6 +141,10 @@
       },
       automatic:{
         default: false,
+        type: Boolean
+      },
+      showUploadButton: {
+        default: true,
         type: Boolean
       }
     },

--- a/src/components/vsUpload/vsUpload.vue
+++ b/src/components/vsUpload/vsUpload.vue
@@ -133,6 +133,10 @@
         default:null,
         type:Object
       },
+      data: {
+        default: null,
+        type: Object
+      },
       automatic:{
         default: false,
         type: Boolean
@@ -293,6 +297,12 @@
         postFiles.forEach((filex)=>{
           formData.append(this.fileName, filex, filex.name)
         })
+        
+        const data = this.data || {};
+
+        for (var key in data) {
+          formData.append(key, data[key]);
+        }
 
         xhr.onerror = function error(e) {
           self.$emit('on-error',e)


### PR DESCRIPTION
- Added prop 'data', so the user can attach form data to the request sending.

- Added prop 'showUploadButton' to enable hiding the upload button in the component and preventing the user from uploading before preproccessing.

use case:
```
<template>
  <vs-upload ref="upload" action=".." :data="data" :show-upload-button="false"/>
  <vs-button @click="submit">Submit</vs-button>
</template>

<script>
export default {
  data () {
    return {
      data: {}
    }
  },
  methods: {
    submit () {
      // process something
      // fetchdata
      var data = fetchData()
      this.data = data
      this.$refs.upload.uploadx('all')
    }
  }
}
</script>
```