### PR TITLE
Add active tab prop to vs-tabs #234

### DIFF
--- a/docs/components/tabs.md
+++ b/docs/components/tabs.md
@@ -5,16 +5,16 @@ API:
    parameters: null
    description: Component that contains the children vs-tab.
    default: null
- - name: vs-tab
-   type: Component
+ - name: v-model
+   type: bind
    parameters: null
-   description: component that wraps everything inside.
+   description: Link active tab index.
    default: null
- - name: vs-label
-   type: String
+ - name: value
+   type: Number, String
    parameters: null
-   description: Text on the tab button.
-   default: null
+   description: Index of active tab.
+   default: 0
  - name: vs-position
    type: String
    parameters: top, left, bottom, right
@@ -29,7 +29,17 @@ API:
    type: String
    parameters: top (default), left, bottom, right
    description: Change the alignment of the tabs buttons.
-   default: top
+   default: top   
+ - name: vs-tab
+   type: Component
+   parameters: null
+   description: component that wraps everything inside.
+   default: null
+ - name: vs-label
+   type: String
+   parameters: null
+   description: Text on the tab button.
+   default: null
 ---
 
 # Tabs **- ssr**


### PR DESCRIPTION
Fixes #234 

## Features
- `v-model` for two-way binding like on a text input or select.
- `value` prop for one-way initialization.
- Respects the `disabled` prop of `vs-tab` and does not set a disabled tab active, thus active tab stays the same.
- Allows invalid values and uses fall-backs to 'fix' them. If the value is negative it will fall back to 0 and set the first tab active. If value is larger than the total number of tabs it will set the last tab active.

## API
```html
<vs-tabs v-model="selectedTab">
    ...
</vs-tabs>
```
```js
export default {
    data: () => ({ selectedTab: 1 })
};
```

or

```html
<vs-tabs :value="selectedTab">
    ...
</vs-tabs>
```
```js
export default {
    data: () => ({ selectedTab: 1 })
};
```

or

```html
<vs-tabs value="1">
    ...
</vs-tabs>
```

I also updated the `mounted` function to reuse existing methods and paid attention to not break any animation or transition.

## Examples & Demo
- [Live Demo](https://jlk3362kl5.codesandbox.io/)
- [CodeSandbox](https://codesandbox.io/s/jlk3362kl5?fontsize=15&hidenavigation=1&module=%2Fsrc%2FApp.vue)