### PR TITLE
Support passing Element into loading container property

### DIFF
--- a/docs/components/loading.md
+++ b/docs/components/loading.md
@@ -10,6 +10,11 @@ API:
    parameters:
    description: function to close loading.
    default: null
+ - name: container
+   type: HTMLElement, String
+   parameters: null
+   description: Container that will be loading, pass a HTMLElement or query selector
+   default: null
  - name: color
    type: String
    parameters: RGB, HEX, primary, danger, success, dark, warning
@@ -325,7 +330,7 @@ For the examples, the request or the delay is simulated with `setTimeout`.
 ```html
 <template lang="html">
   <div class="centerx">
-    <vs-button id="button-with-loading" class="vs-con-loading__container" @click="openLoadingContained" vs-type="relief" vs-color="primary">Button with Loading</vs-button>
+    <vs-button ref="loadableButton" id="button-with-loading" class="vs-con-loading__container" @click="openLoadingContained" vs-type="relief" vs-color="primary">Button with Loading</vs-button>
     <vs-button @click="openLoadingInDiv" vs-type="relief" vs-color="primary">Div with Loading</vs-button>
     <div class="fill-row">
       <div id="div-with-loading" class="vs-con-loading__container">Load Me!</div>
@@ -346,11 +351,11 @@ export default {
       this.$vs.loading({
         background: this.backgroundLoading,
         color: this.colorLoading,
-        container: '#button-with-loading',
+        container: this.refs.loadableButton,
         scale: 0.45
       })
       setTimeout( ()=> {
-        this.$vs.loading.close('#button-with-loading > .con-vs-loading')
+        this.$vs.loading.close(this.refs.loadableButton)
       }, 3000);
     },
     openLoadingInDiv(){

--- a/src/functions/vsLoading/index.js
+++ b/src/functions/vsLoading/index.js
@@ -16,7 +16,7 @@ export default {
       instance.$data.text = parameters.text
       instance.$data.clickEffect = parameters.clickEffect
       if(parameters.container) {
-        containerx = parameters.container instanceof HTMLElement ? parameters.container : document.querySelector(parameters.container)
+        containerx = parameters.container instanceof Element ? parameters.container : document.querySelector(parameters.container)
       }
     }
     instance.vm = instance.$mount();
@@ -25,7 +25,7 @@ export default {
   close(elx){
     let loadings
     
-    if (elx instanceof HTMLElement) {
+    if (elx instanceof Element) {
       // Mimicking the behavior of doing `elx.querySelectorAll('> .con-vs-loading')` but `>` is not well supported.
       // We are doing this because we can only add the respective classes to .con-vs-loading
       loadings = Array.from(elx.children).filter(el => el.classList.contains('.con-vs-loading'))

--- a/src/functions/vsLoading/index.js
+++ b/src/functions/vsLoading/index.js
@@ -23,8 +23,7 @@ export default {
     containerx.insertBefore(instance.vm.$el, containerx.firstChild)
   },
   close(elx){
-    let el = elx || 'body > .con-vs-loading'
-    let loadings = document.querySelectorAll(el)
+    let loadings = elx instanceof HTMLElement ? elx : document.querySelectorAll(elx || 'body > .con-vs-loading')
     loadings.forEach((loading)=>{
       loading.classList.add('beforeRemove')
       setTimeout(()=>{

--- a/src/functions/vsLoading/index.js
+++ b/src/functions/vsLoading/index.js
@@ -16,7 +16,7 @@ export default {
       instance.$data.text = parameters.text
       instance.$data.clickEffect = parameters.clickEffect
       if(parameters.container) {
-        containerx = document.querySelector(parameters.container)
+        containerx = parameters.container instanceof HTMLElement ? parameters.container : document.querySelector(parameters.container)
       }
     }
     instance.vm = instance.$mount();

--- a/src/functions/vsLoading/index.js
+++ b/src/functions/vsLoading/index.js
@@ -23,12 +23,22 @@ export default {
     containerx.insertBefore(instance.vm.$el, containerx.firstChild)
   },
   close(elx){
-    let loadings = elx instanceof HTMLElement ? elx : document.querySelectorAll(elx || 'body > .con-vs-loading')
-    loadings.forEach((loading)=>{
-      loading.classList.add('beforeRemove')
-      setTimeout(()=>{
-        loading.remove()
-      },300)
-    })
+    let loadings
+    
+    if (elx instanceof HTMLElement) {
+      // Mimicking the behavior of doing `elx.querySelectorAll('> .con-vs-loading')` but `>` is not well supported.
+      // We are doing this because we can only add the respective classes to .con-vs-loading
+      loadings = Array.from(elx.children).filter(el => el.classList.contains('.con-vs-loading'))
+    } else {
+      loadings = document.querySelectorAll(elx || 'body > .con-vs-loading')
+    }
+    
+    loadings
+      .forEach((loading)=>{
+        loading.classList.add('beforeRemove')
+        setTimeout(()=>{
+          loading.remove()
+        },300)
+      })
   }
 }


### PR DESCRIPTION
## Summary

This PR allows passing `Element` as the `container` property for the first parameter of `Vue.prototype.$vs.loading`

## Rationale
Refs provide a direct link to the DOM that your component uses, using ID's in Vue is dangerous since components can be spun up and multiple ID's can exist.

Using the Vue ref api we can pass the element itself into the loader to yield a more precise and predictable behavior

## Backwards Compatibility
This change is backwards compatible.

## Example
```html
<template>
    <vs-button class="vs-con-loading__container" vs-color="primary" vs-type="filled" @click="login">Login</vs-button>
</template>

<script lang="ts">
    import Vue from 'vue'
    import { Component } from 'vue-property-decorator'

    @Component()
    export default class Login extends Vue {
        public login () {
            this.$vs.loading({
                container: (this.$refs.login as Vue).$el,
                background: 'primary',
                color: '#FFFFFF',
                scale: 0.45
            })
        }
    }
</script>
```