### PR TITLE
Fixes #257 dropdown component

### DIFF
--- a/src/components/vsDropDown/main.styl
+++ b/src/components/vsDropDown/main.styl
@@ -136,6 +136,14 @@
   z-index: 40000
   transform: translate(-100%);
   transition: opacity .25s, transform .25s, width .3s ease;
+  &::after
+    content: ''
+    display block
+    width 100%
+    height 10px
+    position absolute
+    left 0
+    top 100%
 .vs-dropdown-menu
   background: rgb(255, 255, 255);
   padding-left: 0px !important;

--- a/src/components/vsDropDown/main.styl
+++ b/src/components/vsDropDown/main.styl
@@ -145,7 +145,7 @@
   padding-top: 5px;
   padding-bottom: 5px;
   position: relative;
-  .after
+  &::after
     content: '';
     position: absolute;
     right: 10px;
@@ -159,8 +159,9 @@
     border-top: 1px solid rgba(0, 0, 0, 0.1);
     border-left: 1px solid rgba(0, 0, 0, 0.1);
     z-index: 10;
-&.notHeight
-  .after
+    box-sizing: border-box
+&.notHeight .vs-dropdown-menu
+  &::after
     top: auto;
     bottom: 0px;
     border-top: 1px solid rgba(0, 0, 0, 0.0);

--- a/src/components/vsDropDown/vsDropDownMenu.vue
+++ b/src/components/vsDropDown/vsDropDownMenu.vue
@@ -67,8 +67,6 @@ export default {
     },
     insertBody(){
       let elp = this.$el
-      console.log('instance', elp)
-      let elx = this.$refs.options
       document.body.insertBefore(elp, document.body.firstChild)
     },
   }

--- a/src/components/vsDropDown/vsDropDownMenu.vue
+++ b/src/components/vsDropDown/vsDropDownMenu.vue
@@ -54,7 +54,7 @@ export default {
     this.insertBody()
   },
   beforeDestroy() {
-    this.$destroy()
+    this.$el.parentNode.removeChild(this.$el)
   },
   methods:{
     toggleMenu(event){

--- a/src/components/vsDropDown/vsDropDownMenu.vue
+++ b/src/components/vsDropDown/vsDropDownMenu.vue
@@ -14,7 +14,6 @@
       <ul
         v-if="!vsCustomContent"
         class="vs-component vs-dropdown-menu" >
-        <div class="after"/>
         <slot/>
       </ul>
       <div


### PR DESCRIPTION
Fixes #257 and refactor codes of it.

* Fix `"RangeError: Maximum call stack size exceeded"`.
* Use pseudo element instead of div in ul because of Content models. Div element is not allowed as direct children of ul.
* Enable cursor to touch menu from the lower direction of it.