### PR TITLE
vsTable - fix listener resize event when component is destroyed

### DIFF
--- a/src/components/vsTable/vsTable.vue
+++ b/src/components/vsTable/vsTable.vue
@@ -194,6 +194,9 @@ export default {
       }
     })
   },
+  destroyed () {
+    window.removeEventListener('resize', this.listenerChangeWidth)
+  },
   methods:{
     getItems(min, max) {
       let items = []


### PR DESCRIPTION
Fixed listening to the 'resize' method when the component would be destroyed.

Example:
Go to page: https://lusaxweb.github.io/vuesax/components/table.html
Then go: https://lusaxweb.github.io/vuesax/components/textarea.html
Try window resize and see errors in the console