### PR TITLE
Fix #300 - Correct Pagination Nav Buttons 

### DIFF
--- a/src/components/vsPagination/main.styl
+++ b/src/components/vsPagination/main.styl
@@ -56,6 +56,7 @@
           transform: scale(1.05)
           color: rgb(255,255,255)
           font-weight: bold
+          cursor: default
 
           .effect
             opacity 1
@@ -83,6 +84,11 @@
       margin-right: 5px
     &.btn-next-pagination
       margin-left: 5px
+    &.btn-pagination.disabled
+      color: rgba(0,0,0,.1)
+      cursor: default
+    &.btn-pagination.disabled:hover
+      background: rgb(240,240,240) !important
     i
       font-size: 1.2rem
     &:hover

--- a/src/components/vsPagination/vsPagination.vue
+++ b/src/components/vsPagination/vsPagination.vue
@@ -5,8 +5,10 @@
     class="con-vs-pagination">
     <nav class="nav-pagination">
       <button
+        :class="{disabled:current <= 1 ? 'disabled' : null}"
         class="btn-pagination btn-prev-pagination"
-        @click="prevPage" >
+        @click="prevPage"
+        :disabled="current === 1">
         <i class="material-icons">
           {{ prevIcon }}
         </i>
@@ -27,8 +29,10 @@
       </ul>
       <!-- :style="styleBtn" -->
       <button
+        :class="{disabled:current === total ? 'disabled' : null}"
         class="btn-pagination btn-next-pagination"
-        @click="nextPage" >
+        @click="nextPage"
+        :disabled="current === total">
         <i class="material-icons">
           {{ nextIcon }}
         </i>


### PR DESCRIPTION
Fix the next and previous buttons in pagination to disable them upon hitting max pages and min pages respectively. Also changed cursor on the disabled and active items for pagination to use the default cursor, falling closer in line with web standards,

Fixes #300