### PR TITLE
fix focusValue isn't a function error in select component - issue #344

### DIFF
--- a/src/components/vsSelect/vsSelect.vue
+++ b/src/components/vsSelect/vsSelect.vue
@@ -226,7 +226,6 @@ export default {
         if(this.active){
           utils.insertBody(this.$refs.vsSelectOptions)
           setTimeout( () => {
-            this.$children[0].focusValue(0)
             this.$children.forEach((item)=>{
               if (item.focusValue) {
                 item.focusValue()
@@ -388,7 +387,8 @@ export default {
       if (!this.autocomplete) {
         if(this.multiple?this.value.length == 0:!this.value || this.multiple){
           setTimeout( () => {
-            this.$children[0].$el.querySelector('.vs-select--item').focus()
+            const el = this.$children[0].$el.querySelector('.vs-select--item')
+            if (el) el.focus()
           }, 50);
         }
       }


### PR DESCRIPTION
Live demo
https://lusaxweb.github.io/vuesax/components/selects.html#single-selection
Just open the select menu and check the console, you'll see the error.

This PR also fixes another issue I faced in select component where
```js
this.$children[0].$el.querySelector('.vs-select--item').foucs()
```
would result in can't execute focus on undefined, so I made sure the element is available before focus runs.