### PR TITLE
fix vs-tabs-position-bottom style

### DIFF
--- a/src/components/vsTabs/main.styl
+++ b/src/components/vsTabs/main.styl
@@ -129,9 +129,8 @@
   .vs-tabs--ul
     display: flex
 .vs-tabs-position-bottom
-  display flex
-  flex-direction: column
   .vs-tabs--ul
+    display: flex
     border-top 1px solid rgba(0,0,0,.05)
     border-bottom: 0px !important;
   .con-ul-tabs


### PR DESCRIPTION
### Issue
The PR fixes the style of `<vs-tabs vs-position="bottom">`. 

``` html
<template>
  <div id="app">
    <div>
      <vs-tabs vs-alignment="fixed" vs-position="bottom">
        <vs-tab vs-label="Home">
          <div><h3>Home</h3></div>
        </vs-tab>
        <vs-tab vs-label="Documents">
          <div><h3>Documents</h3></div>
        </vs-tab>
        <vs-tab vs-label="Contributors">
          <div><h3>Contributors</h3></div>
        </vs-tab>
        <vs-tab vs-label="Ecosistem">
          <div><h3>Ecosistem</h3></div>
        </vs-tab>
      </vs-tabs>
    </div>
  </div>
</template>
```
![image](https://user-images.githubusercontent.com/9296143/48231248-78162580-e37b-11e8-9c5c-5df3376cd35f.png)

---
### Test and Fix it
Add `display: flex;` to the `<ul>` like the style of `.vs-tabs-position-top vs-tabs--ul`.

``` css
.vs-tabs-position-bottom,
.vs-tabs-position-top .vs-tabs--ul {
    display: -webkit-box;
    display: -ms-flexbox;
    display: flex
}
```

![image](https://user-images.githubusercontent.com/9296143/48231560-90d30b00-e37c-11e8-8b27-a975cec99bfb.png)

---
It seems like the `flex-direction: column;` is not necessary.

![image](https://user-images.githubusercontent.com/9296143/48231632-caa41180-e37c-11e8-8e4d-6d305c7fad22.png)




