### PR TITLE
fix unused VsButton import on VsTabs.

### DIFF
--- a/src/components/vsTabs/vsTabs.vue
+++ b/src/components/vsTabs/vsTabs.vue
@@ -37,10 +37,8 @@
 
 <script>
 import _color from '../../utils/color.js'
-import vsButton from '../vsButton/vsButton.vue'
 export default {
   name:'VsTabs',
-  components:{vsButton},
   props:{
     value: {
       default: 0,


### PR DESCRIPTION
Removed the imports on `vs-tabs` that is not being used anywhere on this component. It is using normal HTML button.