### PR TITLE
Fix allow types of `to` property in sidebar item.

### DIFF
--- a/src/components/vsSideBar/vsSidebarItem.vue
+++ b/src/components/vsSideBar/vsSidebarItem.vue
@@ -41,7 +41,7 @@ export default {
     },
     to: {
       default:null,
-      type: String
+      type: [String, Object]
     },
     index: {
       default: null,


### PR DESCRIPTION
router-link component allows String and Object value for `to`
property.
But sidebar item allows only String.

see: https://github.com/vuejs/vue-router/blob/dev/src/components/link.js