### PR TITLE
Fix #353, #351

### DIFF
--- a/src/functions/vsDialog/index.vue
+++ b/src/functions/vsDialog/index.vue
@@ -23,7 +23,7 @@
           <vs-icon
             v-if="type=='alert'"
             :icon="vsCloseIcon"
-            :click="close"
+            @click.native="cancelClose"
             :icon-pack="vsIconPack"
             class="vs-dialog-cancel vs-dialog-cancel--icon notranslate"
           />

--- a/src/functions/vsDialog/index.vue
+++ b/src/functions/vsDialog/index.vue
@@ -23,7 +23,7 @@
           <vs-icon
             v-if="type=='alert'"
             :icon="vsCloseIcon"
-            @click.native="cancelClose"
+            @click.native="close"
             :icon-pack="vsIconPack"
             class="vs-dialog-cancel vs-dialog-cancel--icon notranslate"
           />


### PR DESCRIPTION
Capture native click event on vsIcon's root html element and close vsDialog