### PR TITLE
Fix #385 - Add !important to background vs-button-filled

### DIFF
--- a/src/components/vsButton/main.styl
+++ b/src/components/vsButton/main.styl
@@ -107,7 +107,7 @@ for colorx, i in $vs-colors
   .vs-button-{colorx}
     &.vs-button-filled //type filled
       // background: $vs-colors[colorx]
-      background: var(colorx)
+      background: var(colorx) !important
       &:hover
         box-shadow: 0px 8px 25px -8px var(colorx)
     &.vs-button-border,&.vs-button-flat //type border


### PR DESCRIPTION
**Demo:**

![screencast-localhost-7070-2018 12 05-23-14-06](https://user-images.githubusercontent.com/22016005/49554497-a2f48a80-f8e3-11e8-82f2-008656818906.gif)
