### PR TITLE
Fix #382 - Removed $refs colgroup that is not being used anymore

### DIFF
--- a/src/components/vsTable/vsTable.vue
+++ b/src/components/vsTable/vsTable.vue
@@ -347,12 +347,6 @@ export default {
         tdsx.push({index: index, widthx: td.offsetWidth})
       });
 
-      let colgroup = this.$refs.colgroup
-      let cols = colgroup.querySelectorAll('.col')
-      cols.forEach((col, index) => {
-        col.setAttribute('width', tdsx[index].widthx)
-      });
-
       let colgrouptable = this.$refs.colgrouptable
       let colsTable = colgrouptable.querySelectorAll('.col')
       colsTable.forEach((col, index) => {


### PR DESCRIPTION
This address #382 .
There's some commented code at line 25 to 54 inside VsTable.vue component:

```html
<!-- <div class="vs-con-table-theade vs-table--thead">
        <table
          :style="tableHeaderStyle"
          class="vs-table--thead-table">
          <colgroup ref="colgroup">
            <col width="20"/>
            <col
              v-for="(col,index) in getThs"
              :key="index"
              :name="`col-${index}`"
              class="colx">
          </colgroup>
          <thead ref="thead">
            <tr>
              <th class="td-check">
                <span
                  v-if="multiple"
                  class="con-td-check">
                  <vs-checkbox
                    :icon="isCheckedLine ? 'remove' : 'check'"
                    :checked="isCheckedMultiple"
                    size="small"
                    @click="changeCheckedMultiple"/>
                </span>
              </th>
              <slot name="thead"></slot>
            </tr>
          </thead>
        </table>
      </div> -->
```

So I removed the reference to `colgroup` because it's commented out. Please check if this code isn't necessary anymore. If it's not, then this PR should be good.