### PR TITLE
Fix #392 - Added two new props to textarea (width and height)

### DIFF
--- a/docs/.vuepress/components/Demos/Textarea/Height.vue
+++ b/docs/.vuepress/components/Demos/Textarea/Height.vue
@@ -1,0 +1,5 @@
+<template lang="html">
+  <div>
+    <vs-textarea label="Height set to 200px" height="200px" />
+  </div>
+</template>

--- a/docs/.vuepress/components/Demos/Textarea/Width.vue
+++ b/docs/.vuepress/components/Demos/Textarea/Width.vue
@@ -1,0 +1,5 @@
+<template lang="html">
+  <div>
+    <vs-textarea label="Width set to 300px" width="300px" />
+  </div>
+</template>

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -141,21 +141,44 @@ export default {
 
 <box>
 
-## Width/Height
+## Width
 
-You can set the width of the textarea width the `width` property, and the height with the `height` property.
+You can set the width of the textarea width the `width` property.
 
 <vuecode md>
 <div slot="demo">
-  <Demos-Height-Counter />
+  <Demos-Textarea-Width />
 </div>
 <div slot="code">
 
 ```html
 <template lang="html">
   <div>
-    <vs-textarea label="Width" width="300px" />
-    <vs-textarea label="Height" height="300px" />
+    <vs-textarea label="Width set to 300px" width="300px" />
+  </div>
+</template>
+```
+
+</div>
+</vuecode>
+</box>
+
+<box>
+
+## Height
+
+You can set the height of the textarea with the `height` property.
+
+<vuecode md>
+<div slot="demo">
+  <Demos-Textarea-Height />
+</div>
+<div slot="code">
+
+```html
+<template lang="html">
+  <div>
+    <vs-textarea label="Height set to 200px" height="200px" />
   </div>
 </template>
 ```

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -15,6 +15,16 @@ API:
    parameters: null
    description: Determine if the value exceeds the counter.
    default: false
+ - name: width
+   type: String
+   parameters: null
+   description: Set the width of the textarea
+   default: null
+ - name: height
+   type: String
+   parameters: null
+   description: Set the height of the textarea
+   default: null
 ---
 
 # Textarea
@@ -123,6 +133,31 @@ export default {
 
 <style lang="stylus">
 </style>
+```
+
+</div>
+</vuecode>
+</box>
+
+<box>
+
+## Width/Height
+
+You can set the width of the textarea width the `width` property, and the height with the `height` property.
+
+<vuecode md>
+<div slot="demo">
+  <Demos-Height-Counter />
+</div>
+<div slot="code">
+
+```html
+<template lang="html">
+  <div>
+    <vs-textarea label="Width" width="300px" />
+    <vs-textarea label="Height" height="300px" />
+  </div>
+</template>
 ```
 
 </div>

--- a/src/components/vsTextarea/vsTextarea.vue
+++ b/src/components/vsTextarea/vsTextarea.vue
@@ -1,6 +1,7 @@
 <template lang="html">
   <div
     :class="{'textarea-danger': counter ? value.length > counter : false, 'focusx': focusx}"
+    :style="getStyle"
     class="vs-component vs-con-textarea">
 
     <h4 v-if="label">
@@ -10,6 +11,7 @@
     <textarea
       :value="value"
       v-bind="$attrs"
+      :style="getStyle"
       class="vs-textarea"
       v-on="listeners">
     </textarea>
@@ -40,12 +42,32 @@ export default {
     counterDanger:{
       default: false,
       type: Boolean
+    },
+    height:{
+      default:null,
+      type: String
+    },
+    width:{
+      default:null,
+      type: String
     }
   },
   data:()=>({
     focusx: false
   }),
   computed:{
+    getStyle() {
+      let style = ''
+      if (this.height) {
+        style = `height:${this.height};`
+      }
+
+      if (this.width) {
+        style += `width:${this.width};`
+      }
+
+      return style
+    },
     listeners() {
       return {
         ...this.$listeners,


### PR DESCRIPTION
This is to fix #392 , where the problem is if you set a class to `<vs-textarea>` today to change the height, only the `<div>` changes it's height, and it should also change the textarea's height. 

So, to fix this and prevent the same problem from happen with the width, I added two new props to textarea, that adds an width/height style (both optional) to the `<div>` and the `<textarea>` inside of it.

**Demo:**

![screencast-localhost-7070-2018 12 07-16-42-36](https://user-images.githubusercontent.com/22016005/49666423-35f60780-fa3f-11e8-9ee8-01a2201314fa.gif)
