### PR TITLE
Fix #369 - Padding left with icon after

### DIFF
--- a/docs/.vuepress/components/Demos/Input/Icons.vue
+++ b/docs/.vuepress/components/Demos/Input/Icons.vue
@@ -29,5 +29,5 @@ export default {
 <style lang="stylus">
 .icons-example
   .vs-input
-    margin 6px;
+    margin 15px
 </style>

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -293,7 +293,7 @@ export default {
 <style lang="stylus">
 .icons-example
   .vs-input
-    margin 6px;
+    margin 15px
 </style>
 ```
 

--- a/src/components/vsInput/main.styl
+++ b/src/components/vsInput/main.styl
@@ -147,11 +147,13 @@
     + .vs-input--placeholder
       padding-left: 32px;
   &.icon-after-input
-    padding-left: 1.75rem !important
     padding-right: 1.75rem
     + .vs-input--placeholder
-      padding-left: 1.75rem
       padding-right: 1.75rem
+  &.hasIcon.icon-after-input
+    padding-left: .85em;
+    + .vs-input--placeholder
+      padding-left: .85em;
   &:disabled
     opacity: $vs-disabled-opacity;
     cursor: default;


### PR DESCRIPTION
This fix a part of #369 . I could not fix the placeholders vertical middle alignment.

**Fix made:** 
![screenshot from 2018-12-07 17-03-52](https://user-images.githubusercontent.com/22016005/49670005-4fe91780-fa4a-11e8-8dc2-0dc67d18a24c.png)

----------------------------------
**Note:** I also change the spaces between the Icons.vue in VsInput.vue Demos, because they were a bit too close in my opinion from one another. See below:

![image](https://user-images.githubusercontent.com/22016005/49670118-af472780-fa4a-11e8-8c99-78b14e6b2361.png)
