### PR TITLE
Fix one word typo in VsSelect docs

### DIFF
--- a/docs/components/selects.md
+++ b/docs/components/selects.md
@@ -770,7 +770,7 @@ You can group elements with the sub component `vs-select-group`
   <div class="con-select-example">
     <vs-select
         class="selectExample"
-        label="Defautl"
+        label="Default"
         v-model="select1"
         >
         <div :key="index" v-for="item,index in options1">


### PR DESCRIPTION
From "Defautl" to "Default" :)