### PR TITLE
Updates the input control to add a validation icon pack parameter

### DIFF
--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -45,6 +45,11 @@ API:
    parameters: Icon Pack Class Name
    description: Icon Pack to be used. If not set, icon will default to Material Icons. ex. FA4 uses fa or fas, FA5 uses fas, far, or fal.
    default: material-icons
+ - name: val-icon-pack
+   type: String
+   parameters: Validation Icon Pack Class Name
+   description: Icon Pack to be used by the Validation Icons. If not set, icon will default to Material Icons. ex. FA4 uses fa or fas, FA5 uses fas, far, or fal.
+   default: material-icons
  - name: icon-after
    type: Boolean,String
    parameters: null
@@ -251,7 +256,7 @@ The input can have icons. Use the property `icon`. You can also also manipulate 
 ::: tip
 Vuesax uses the **Google Material Icons** font library. For a list of all available icons, visit the official [Material Icons page](https://material.io/icons/).
 
-FontAwesome and other fonts library are supported. Simply use the `icon-pack` with `fa` or `fas`. You still need to include the Font Awesome icons in your project.
+FontAwesome and other fonts library are supported. Simply use the `icon-pack` and `val-icon-pack` parameters with `fa` or `fas`. You still need to include the Font Awesome icons in your project.
 
 :::
 

--- a/src/components/vsInput/vsInput.vue
+++ b/src/components/vsInput/vsInput.vue
@@ -63,7 +63,7 @@
           :class="{'icon-before':iconAfter}">
           <vs-icon
             :class="{'icon-before':iconAfter}"
-            :iconPack="iconPack"
+            :valIconPack="valIconPack"
             :icon="getIcon"
           ></vs-icon>
         </span>
@@ -186,6 +186,10 @@ export default {
     },
     size:{
       default:'normal',
+      type:String
+    },
+    valIconPack:{
+      default:'material-icons',
       type:String
     },
     valIconSuccess:{


### PR DESCRIPTION
This fixes an edge case I have where the main `icon` is coming from a different `icon-pack` from the icons used for validation like `val-icon-success`.

It maintains the same default as the `icon-pack` but differentiates it.