### PR TITLE
Fix #345 - Added a few validations to beforeDestroy hook

### DIFF
--- a/src/components/vsSelect/vsSelect.vue
+++ b/src/components/vsSelect/vsSelect.vue
@@ -425,7 +425,6 @@ export default {
       this.active = false
       this.setLabelClass(this.$refs.inputSelectLabel, false)
       document.removeEventListener('click',this.clickBlur)
-      this.active = true
     },
     changePosition(){
       let elx = this.$refs.inputselect

--- a/src/components/vsSelect/vsSelect.vue
+++ b/src/components/vsSelect/vsSelect.vue
@@ -258,7 +258,12 @@ export default {
   },
   beforeDestroy() {
     let [parent] = document.getElementsByTagName('body')
-    parent.removeChild(this.$refs.vsSelectOptions)
+
+    if (parent &&
+        this.$refs.vsSelectOptions &&
+        this.$refs.vsSelectOptions.parentNode === parent) {
+      parent.removeChild(this.$refs.vsSelectOptions)
+    }
   },
   updated(){
     if(!this.active){
@@ -420,6 +425,7 @@ export default {
       this.active = false
       this.setLabelClass(this.$refs.inputSelectLabel, false)
       document.removeEventListener('click',this.clickBlur)
+      this.active = true
     },
     changePosition(){
       let elx = this.$refs.inputselect


### PR DESCRIPTION
Testing using `debugger` seems to fix this. 

You can see in the image below that the `parentNode` of `this.$refs.vsSelectOptions.parentNode` it's the same, so adding this conditional in the `beforeDestroy()` hook resolved the issue #345 .

![image](https://user-images.githubusercontent.com/22016005/49735606-c5cdc880-fc6e-11e8-8ce2-6323bac29d11.png)
