### PR TITLE
fix transform animations in card footer

### DIFF
--- a/src/components/vsCard/main.styl
+++ b/src/components/vsCard/main.styl
@@ -29,7 +29,7 @@
   transform: translate(0,40%)
   margin-top: -5%
   padding-top: 0px
-  overflow hidden
+  // overflow hidden
   &.fixedHeight
     position: absolute
     bottom: 0


### PR DESCRIPTION
The footer default overflow causes a little visual bug in animated actions if it uses `translateY`.

![untitled project](https://user-images.githubusercontent.com/19931838/50722813-f7924d80-10bb-11e9-8520-c64e8836e844.gif)

Didn't found any reason for the overflow hidden by default in footer.

This PR solve the problem 😄