### PR TITLE
removed black background on active item style in vsTabs + disabled tab fixed

### DIFF
--- a/src/components/vsTabs/vsTabs.vue
+++ b/src/components/vsTabs/vsTabs.vue
@@ -15,12 +15,12 @@
           :class="{'activeChild':childActive == index}"
           class="vs-tabs--li"
           @mouseover="hover = true"
-          @mouseout="hover = false"
-          @click="activeChild(index)">
+          @mouseout="hover = false">
           <button
             v-bind="child.attrs"
             type="button"
             :style="styleAlignIcon(child.icon)"
+            @click="activeChild(index)"
             v-on="child.listeners">
             <vs-icon v-if="child.icon" :icon="child.icon" :color="color" style="padding-right:9px"></vs-icon>
             <span>{{ child.label }}</span>

--- a/src/style/components/vsTabs.styl
+++ b/src/style/components/vsTabs.styl
@@ -192,8 +192,6 @@ for colorx, i in $vs-colors
     .activeChild
       button
         color: getColor(colorx, 1) !important
-        &:active
-          background rgb(0,0,0)
 
     .line-vs-tabs
       background: linear-gradient(30deg, getColor(colorx, 1) 0%, getColor(colorx, .5) 100%) !important

--- a/src/style/components/vsTabs.styl
+++ b/src/style/components/vsTabs.styl
@@ -118,6 +118,10 @@
     transition all .2s ease
     &:hover:not(:disabled)
       color inherit
+  button:disabled
+    opacity .5
+    cursor default !important
+    pointer-events: none
 .activeChild
   button:not(:disabled)
     color inherit
@@ -183,9 +187,6 @@
 
 for colorx, i in $vs-colors
   .vs-tabs-{colorx}
-    button:disabled
-      opacity .5
-      cursor default !important
     button:not(:disabled)
       &:hover
         color: getColor(colorx, 1) !important


### PR DESCRIPTION
removed black background on active item style in vsTabs component when clicked again.

This is regarding issue [459](https://github.com/lusaxweb/vuesax/issues/459) of mine.

before:
![chrome-capture](https://user-images.githubusercontent.com/47495003/52533324-391bb580-2d58-11e9-82be-ec1300eb4284.gif)

After:
![chrome-capture 2](https://user-images.githubusercontent.com/47495003/52533329-40db5a00-2d58-11e9-825c-e5afe218f828.gif)
