### PR TITLE
Safari radio fix

### DIFF
--- a/src/components/vsRadio/vsRadio.vue
+++ b/src/components/vsRadio/vsRadio.vue
@@ -42,6 +42,7 @@ export default {
     listeners(){
         return {
           ...this.$listeners,
+          input: () => this.$emit('input', this.vsValue),
           click: () => this.$emit('input', this.vsValue)
         }
     },

--- a/src/components/vsRadio/vsRadio.vue
+++ b/src/components/vsRadio/vsRadio.vue
@@ -9,7 +9,7 @@
       :name="value"
       type="radio"
       class="vs-radio--input"
-      v-on:click="listeners">
+      v-on="listeners">
     <span
       class="vs-radio">
       <span
@@ -39,6 +39,12 @@ export default {
     }
   },
   computed:{
+    listeners(){
+        return {
+          ...this.$listeners,
+          click: () => this.$emit('input', this.vsValue)
+        }
+    },
     attrs(){
       let attrsx = JSON.parse(JSON.stringify(this.$attrs))
       return {
@@ -63,10 +69,7 @@ export default {
   methods:{
     giveColor(color,opacity){
       return _color.rColor(color,opacity)
-    },
-    listeners(){
-      this.$emit('input', this.vsValue)
-    },
+    }
   }
 }
 </script>

--- a/src/components/vsRadio/vsRadio.vue
+++ b/src/components/vsRadio/vsRadio.vue
@@ -6,9 +6,10 @@
       v-bind="$attrs"
       :checked="isChecked"
       :value="value"
+      :name="value"
       type="radio"
       class="vs-radio--input"
-      v-on="listeners">
+      v-on:click="listeners">
     <span
       class="vs-radio">
       <span
@@ -38,12 +39,6 @@ export default {
     }
   },
   computed:{
-    listeners(){
-      return {
-        ...this.$listeners,
-        input: () => this.$emit('input', this.vsValue)
-      }
-    },
     attrs(){
       let attrsx = JSON.parse(JSON.stringify(this.$attrs))
       return {
@@ -68,6 +63,9 @@ export default {
   methods:{
     giveColor(color,opacity){
       return _color.rColor(color,opacity)
+    },
+    listeners(){
+      this.$emit('input', this.vsValue)
     },
   }
 }

--- a/src/style/components/vsRadio.styl
+++ b/src/style/components/vsRadio.styl
@@ -29,6 +29,7 @@
   transition: all .25s ease;
   background: transparent;
   top: 0px;
+  border: 2px solid rgb(200, 200, 200);
 
 .vs-radio--circle
   transition: all .25s ease;


### PR DESCRIPTION
Bug fix related to this bug:
#378 
"radio not working in Safari"

![image](https://user-images.githubusercontent.com/30797402/53170959-b3aec580-35e1-11e9-9ca5-27fe946827e4.png)


The problem was that input elements didn't have a name attribute and some browsers couldn't recognize the "group" of radio inputs. To fix this problem I added attribute name to the input element (based on a model which they are sharing) and I also fixed design bug which appeared after fixing attribute name. I also slightly changed the listener of the input element because somehow "v-on" didn't work in Safari. After all the radio component should be working without any changes in existing projects.