### PR TITLE
Fix #419 - Dialog cancel button not displayed on IE & Edge

### DIFF
--- a/src/functions/vsDialog/index.vue
+++ b/src/functions/vsDialog/index.vue
@@ -42,7 +42,7 @@
             :type="isPrompt?vsButtonAccept:buttonAccept"
             @click="acceptDialog">{{ isPrompt?vsAcceptText:acceptText }}</vs-button>
           <vs-button
-            :color="'rgb(0,0,0,.5)'"
+            :text-color="'rgba(0,0,0,.5)'"
             :type="isPrompt?vsButtonCancel:buttonCancel"
             @click="cancelClose">{{ isPrompt?vsCancelText:cancelText }}</vs-button>
         </footer>


### PR DESCRIPTION
Safari/IE/Edge couldn't translate rgb(0,0,0,0.5) to rgba(0,0,0,0.5). After so many hours of debugging a finally added 'a' and it magically worked 😄. I also change the prop color to text-color because it looks nicer with :hover.

> with prop color

<img width="423" alt="screenshot 2019-02-21 at 18 18 01" src="https://user-images.githubusercontent.com/30797402/53188200-241b0e00-3605-11e9-9063-01d0ad5848cc.png">

> with prop text-color

<img width="445" alt="screenshot 2019-02-21 at 18 18 18" src="https://user-images.githubusercontent.com/30797402/53188203-25e4d180-3605-11e9-9804-d62992c9d357.png">
