### PR TITLE
colors.js's color vars fixed

### DIFF
--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -64,13 +64,13 @@ export default {
         return colorx
       } else {
         if(vscolors.includes(colorx)){
-          return `rgba(var(--${colorx}),${opacity})`
+          return `rgba(var(--vs-${colorx}),${opacity})`
         } else {
-          return `rgba(var(--primary),${opacity})`
+          return `rgba(var(--vs-primary),${opacity})`
         }
       }
     } else {
-      return `rgba(var(--primary),${opacity})`
+      return `rgba(var(--vs-primary),${opacity})`
     }
   },
   contrastColor(elementx) {
@@ -115,7 +115,7 @@ export default {
 
     if(colores.includes(colorInicial)){
       let style = getComputedStyle(document.documentElement)
-      colorx = this.getVariable(style,'--'+colorInicial)
+      colorx = this.getVariable(style,'--vs-'+colorInicial)
     } else {
       if(/[rgb()]/g.test(colorInicial)){
         colorx = colorInicial.replace(/[rgb()]/g,'')
@@ -123,10 +123,10 @@ export default {
         let rgbx = this.hexToRgb(colorInicial)
         colorx = `${rgbx.r},${rgbx.g},${rgbx.b}`
       } else {
-        colorx = '--'+colorInicial
+        colorx = '--vs-'+colorInicial
       }
     }
     return colorx
-    // this.setCssVariable('--'+clave,colorx)
+    // this.setCssVariable('--vs-'+clave,colorx)
   }
 }


### PR DESCRIPTION
I have fixed colors.js in `/src/utils/`

As you changed css3 variables, from `--primary` to `--vs-primary` you forget to change them `colors.js`.

So, please review it and merge it.

As per my testing this solves dropdown item hover issue.

before:
![b4](https://user-images.githubusercontent.com/47495003/53245403-9ce89b80-36d3-11e9-8923-9567ef69cea2.png)

After:
![afterdd](https://user-images.githubusercontent.com/47495003/53245412-a245e600-36d3-11e9-9f40-c33310d09d90.png)
