### PR TITLE
Fix #384 - Clicking on custom content in dropdown was closing it

### DIFF
--- a/src/components/vsDropDown/vsDropDown.vue
+++ b/src/components/vsDropDown/vsDropDown.vue
@@ -73,9 +73,7 @@ export default {
       dropdownMenu.vsCustomContent = this.vsCustomContent
       dropdownMenu.vsTriggerClick = this.vsTriggerClick
       if ((this.vsTriggerClick || this.vsCustomContent) && this.vsDropdownVisible) {
-        if ((el.target !== this.$refs.dropdown &&
-        el.target.parentNode !== this.$refs.dropdown &&
-        el.target.parentNode.parentNode !== this.$refs.dropdown)) {
+        if(!dropdownMenu.$refs["options"].contains(el.target) && !this.$refs["dropdown"].contains(el.target)){
           dropdownMenu.dropdownVisible = this.vsDropdownVisible = false
           document.removeEventListener('click', this.clickx)
         }


### PR DESCRIPTION
Condition for checking wheter the clicked element is inside of the dropdown content wasn't defined right way

> Before
![before](https://user-images.githubusercontent.com/30797402/53267972-176de700-36e5-11e9-934d-a73edc9b41b0.gif)

> After
![after](https://user-images.githubusercontent.com/30797402/53267977-19d04100-36e5-11e9-88b1-84c614719d44.gif)


