### PR TITLE
Removing disabling of vsUpload's input element

### DIFF
--- a/src/components/vsUpload/vsUpload.vue
+++ b/src/components/vsUpload/vsUpload.vue
@@ -13,7 +13,6 @@
       <input
         ref="fileInput"
         v-bind="$attrs"
-        :disabled="$attrs.disabled || limit?(srcs.length - itemRemove.length) >= Number(limit):false"
         type="file"
         @change="getFiles">
       <span class="text-input">


### PR DESCRIPTION
Why? because FormData constructor ignores disabled inputs