### PR TITLE
fix removing a vs-tab from vs-tabs component.

### DIFF
--- a/src/components/vsTabs/vsTab.vue
+++ b/src/components/vsTabs/vsTab.vue
@@ -37,6 +37,14 @@ export default {
       listeners: this.$listeners,
       attrs: this.$attrs
     })
+  },
+  destroyed(){
+    this.$parent.children.forEach(item => {
+      if (item.id === this.id) {
+        const index = this.$parent.children.indexOf(item)
+        this.$parent.children.splice(index, 1)
+      }
+    })
   }
 }
 </script>

--- a/src/components/vsTabs/vsTabs.vue
+++ b/src/components/vsTabs/vsTabs.vue
@@ -118,41 +118,42 @@ export default {
       return activeIndex;
     },
     activeChild(index, initialAnimation){
-      initialAnimation = !!initialAnimation;
-      const elem = this.$refs.li[index]
-      if(this.childActive == index && !initialAnimation){
-        this.these = true
-        elem.classList.add('isActive')
-        setTimeout(()=>{
-          elem.classList.remove('isActive')
-          this.these = false
-        }, 200);
-      }
-
-      this.$children.map((item,item_index)=>{
-        if(item_index != index) {
-          item.active = false
+      if(this.$children[index]){
+        initialAnimation = !!initialAnimation;
+        const elem = this.$refs.li[index]
+        if(this.childActive == index && !initialAnimation){
+          this.these = true
+          elem.classList.add('isActive')
+          setTimeout(()=>{
+            elem.classList.remove('isActive')
+            this.these = false
+          }, 200);
         }
-      })
 
-      if(this.childActive > index){
-        this.$children[index].invert = true
-        this.$children[this.childActive].invert = false
-      } else {
-        this.$children[this.childActive].invert = true
-        this.$children[index].invert = false
+        this.$children.map((item,item_index)=>{
+          if(item_index != index) {
+            item.active = false
+          }
+        })
+
+        if(this.childActive > index){
+          this.$children[index].invert = true
+          this.$children[this.childActive].invert = false
+        } else {
+          this.$children[this.childActive].invert = true
+          this.$children[index].invert = false
+        }
+
+        this.$children[index].active = true
+        this.childActive = index
+        this.$emit('input', this.childActive)
+
+        if(this.vsPosition == 'left' || this.vsPosition == 'right'){
+          this.$children[index].vertical = true
+        }
+
+        this.changePositionLine(elem, initialAnimation)
       }
-
-      this.$children[index].active = true
-      this.childActive = index
-      this.$emit('input', this.childActive)
-
-      if(this.vsPosition == 'left' || this.vsPosition == 'right'){
-        this.$children[index].vertical = true
-      }
-
-      this.changePositionLine(elem, initialAnimation)
-
     },
     changePositionLine(elem, initialAnimation){
       if(this.vsPosition == 'left' || this.vsPosition == 'right'){


### PR DESCRIPTION
when creating vs-tab in a vs-tabs component using an array, removing an item from that list would actually remove the tab content but the tab label in the vs-tabs component stills the same.
I created a destroyed cycle in vs-tab to remove the children components from the parent.
modified vs-Tabs file is because having zero tab in vs-tabs were not defined so I had to make activeChild method to first check if any child exist then do whatever it is there to do.