### PR TITLE
remove the default span container

### DIFF
--- a/src/components/vsTable/vsTable.vue
+++ b/src/components/vsTable/vsTable.vue
@@ -4,10 +4,7 @@
     class="vs-component vs-con-table">
     <!-- header -->
     <header class="header-table vs-table--header">
-      <span>
         <slot name="header"></slot>
-      </span>
-
       <div
         v-if="search"
         class="con-input-search vs-table--search">


### PR DESCRIPTION
If we need to put some html element in the header (div's with some flex etc) it could be complicated to have a span parent. Not every html element is allowed inside a span tag https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2.