### PR TITLE
Fix #511 - vs-Select sometimes opens and closes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ yarn.lock
 *.ntvs*
 *.njsproj
 *.sln
+
+\.vs/

--- a/src/components/vsSelect/vsSelect.vue
+++ b/src/components/vsSelect/vsSelect.vue
@@ -39,6 +39,7 @@
         :icon-pack="iconPack"
         :icon="icon"
         class="icon-select vs-select--icon"
+        @click.once
       ></vs-icon>
 
       <transition name="fadeselect">
@@ -214,7 +215,7 @@ export default {
         },
         focus: (event) => {
           this.$emit('focus',event)
-          // document.removeEventListener('click',this.clickBlur)
+          //document.removeEventListener('click',this.clickBlur)
           this.focus(event)
         },
         input: (event) => {


### PR DESCRIPTION
It seemed to only exhibit behaviour on click of the icon, so added some event modifiers to prevent double signaling on the click event.  Could not reproduce issue after change.  Chrome 73.0.3683.103