### PR TITLE
Fixed: Table Head with more than 5 heading. Expandable Data don't get colspan of all th + Dropdown Component Update

### DIFF
--- a/docs/.vuepress/components/Demos/Table/Expandable.vue
+++ b/docs/.vuepress/components/Demos/Table/Expandable.vue
@@ -44,7 +44,7 @@
             <div class="con-expand-users">
               <div class="con-btns-user">
                 <div class="con-userx">
-                  <vs-avatar :badge="tr.id" size="45px" :src="`https://randomuser.me/api/portraits/women/${indextr}.jpg`"/>
+                  <vs-avatar :badge="tr.id" size="45px" :src="`https://randomuser.me/api/portraits/women/${tr.id}.jpg`"/>
                   <span>
                     {{ tr.name }}
                   </span>

--- a/src/components/vsDropDown/vsDropDown.vue
+++ b/src/components/vsDropDown/vsDropDown.vue
@@ -4,6 +4,7 @@
     ref="dropdown"
     v-bind="$attrs"
     class="vs-con-dropdown parent-dropdown"
+    type="button"
     v-on="listeners">
     <slot/>
   </button>

--- a/src/components/vsTable/vsTr.vue
+++ b/src/components/vsTable/vsTr.vue
@@ -11,7 +11,6 @@
         :class="[`tr-table-state-${state}`, {'is-selected':isSelected, 'selected': data, 'is-expand': maxHeight != '0px', 'activeEdit': activeEdit, 'hoverFlat': $parent.hoverFlat}]"
         class="tr-values vs-table--tr">
         <td
-          v-if="$slots.expand || $parent.multiple"
           class="td-check"
           :class="{'active-expanded': this.expanded}"
           @click="clicktd($event)">
@@ -80,7 +79,6 @@ export default {
   mounted () {
     this.$nextTick(() => {
       this.colspan = this.$parent.$refs.thead.querySelectorAll('th').length
-      console.log(this.$parent);
       if (this.$slots.expand || this.$parent.multiple) {
         this.colspan++
       }

--- a/src/components/vsTable/vsTr.vue
+++ b/src/components/vsTable/vsTr.vue
@@ -112,7 +112,7 @@ export default {
         tr.classList.add('tr-expandedx')
         let trx = Vue.extend(trExpand);
         let instance = new trx();
-        instance.$props.colspan = 5
+        instance.$props.colspan = this.colspan
         instance.$slots.default = this.$slots.expand
         instance.vm = instance.$mount();
         var newTR = document.createElement('tr').appendChild(instance.vm.$el);

--- a/src/components/vsTable/vsTr.vue
+++ b/src/components/vsTable/vsTr.vue
@@ -11,6 +11,7 @@
         :class="[`tr-table-state-${state}`, {'is-selected':isSelected, 'selected': data, 'is-expand': maxHeight != '0px', 'activeEdit': activeEdit, 'hoverFlat': $parent.hoverFlat}]"
         class="tr-values vs-table--tr">
         <td
+          v-if="$slots.expand || $parent.multiple"
           class="td-check"
           :class="{'active-expanded': this.expanded}"
           @click="clicktd($event)">

--- a/src/components/vsTable/vsTr.vue
+++ b/src/components/vsTable/vsTr.vue
@@ -80,8 +80,9 @@ export default {
   mounted () {
     this.$nextTick(() => {
       this.colspan = this.$parent.$refs.thead.querySelectorAll('th').length
-      if (this.$slots.expand) {
-        this.colspan ++
+      console.log(this.$parent);
+      if (this.$slots.expand || this.$parent.multiple) {
+        this.colspan++
       }
     })
   },

--- a/src/components/vsTable/vsTr.vue
+++ b/src/components/vsTable/vsTr.vue
@@ -79,7 +79,7 @@ export default {
   mounted () {
     this.$nextTick(() => {
       this.colspan = this.$parent.$refs.thead.querySelectorAll('th').length
-      if (this.$slots.expand || this.$parent.multiple) {
+      if (this.$slots.expand) {
         this.colspan++
       }
     })

--- a/src/components/vsTable/vsTr.vue
+++ b/src/components/vsTable/vsTr.vue
@@ -7,6 +7,7 @@
         v-if="!$parent.notSpacer"
         class="tr-spacer"></tr> -->
       <tr
+        ref="tableTr"
         @click="clicktr"
         :class="[`tr-table-state-${state}`, {'is-selected':isSelected, 'selected': data, 'is-expand': maxHeight != '0px', 'activeEdit': activeEdit, 'hoverFlat': $parent.hoverFlat}]"
         class="tr-values vs-table--tr">
@@ -58,6 +59,16 @@ export default {
     maxHeight:'0px',
     activeEdit: false
   }),
+  watch: {
+    '$parent.currentx'() {
+      if(this.expanded){
+        const tr = this.$refs.tableTr
+        tr.parentNode.removeChild(tr.nextSibling)
+        tr.classList.remove('tr-expandedx')
+        this.expanded = false
+      }
+    }
+  },
   computed:{
     styleExpand () {
       return {

--- a/src/style/components/vsTable.styl
+++ b/src/style/components/vsTable.styl
@@ -193,6 +193,7 @@ td
   justify-content: center
   max-width: 200px
   position: relative
+  margin-left: auto
   i
     position: absolute
     transition: all .25s ease


### PR DESCRIPTION
If we use header more than 5 in table heading, expandable data dont get full width due to colspan hardcoded to 5.
Which results in something like below.
![colspan](https://user-images.githubusercontent.com/47495003/57017987-2752fb80-6c3f-11e9-9800-7ee4f55b67b6.png)
If fixed this by just assigning varibale which was already created in component but not used.
~ Thanks