### PR TITLE
WIP: Adding 'drop right' to the vsDropdown component

### DIFF
--- a/src/components/vsDropDown/vsDropDown.vue
+++ b/src/components/vsDropDown/vsDropDown.vue
@@ -30,6 +30,10 @@ export default {
     vsCustomContent:{
       default:false,
       type:Boolean
+    },
+    vsDropRight:{
+      default:false,
+      type:Boolean
     }
   },
   data:()=>({
@@ -73,6 +77,7 @@ export default {
       })
       dropdownMenu.vsCustomContent = this.vsCustomContent
       dropdownMenu.vsTriggerClick = this.vsTriggerClick
+      dropdownMenu.vsDropRight = this.vsDropRight
       if ((this.vsTriggerClick || this.vsCustomContent) && this.vsDropdownVisible) {
         if ((evt.target !== this.$refs.dropdown &&
         evt.target.parentNode !== this.$refs.dropdown &&
@@ -117,7 +122,7 @@ export default {
         if(this.$refs.dropdown.getBoundingClientRect().left + dropdownMenu.$el.offsetWidth >= w - 25){
           this.rightx = true
         }
-        dropdownMenu.leftx = this.$refs.dropdown.getBoundingClientRect().left + this.$refs.dropdown.clientWidth
+        dropdownMenu.leftx = this.$refs.dropdown.getBoundingClientRect().left + (this.vsDropRight ? dropdownMenu.$el.clientWidth : this.$refs.dropdown.clientWidth );
       });
     },
     clickToogleMenu(evt){

--- a/src/components/vsDropDown/vsDropDownMenu.vue
+++ b/src/components/vsDropDown/vsDropDownMenu.vue
@@ -24,7 +24,7 @@
         class="vs-dropdown--custom vs-dropdown--menu">
         <slot/>
       </div>
-      <div class="vs-dropdown--menu--after" ref="menuAfter"></div>
+      <div :class="[ vsDropRight ? 'vs-dropdown-right--menu--after' : 'vs-dropdown--menu--after']" ref="menuAfter"></div>
     </div>
   </transition>
 </template>
@@ -39,6 +39,7 @@ export default {
     topx:0,
     rightx:true,
     vsTriggerClick:false,
+    vsDropRight:false,
     widthx:0,
     notHeight:false,
     vsCustomContent:false,

--- a/src/style/components/vsDropDown.styl
+++ b/src/style/components/vsDropDown.styl
@@ -163,6 +163,19 @@
   position: relative;
   margin: 0px;
 
+.vs-dropdown-right--menu--after
+  position: absolute;
+  left: 20px;
+  width: 10px;
+  height: 10px;
+  display: block;
+  background: rgb(255, 255, 255);
+  transform: rotate(45deg) translate(-7px);
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+  border-left: 1px solid rgba(0, 0, 0, 0.1);
+  z-index: 10;
+  box-sizing: border-box
+
 .vs-dropdown--menu--after
   position: absolute;
   right: 10px;


### PR DESCRIPTION
This feature lets you choose the direction of the dropdown menu, by default the menu will drop to the left and my adding `vs-drop-right` it will drop to the right.

Signed-off-by: Lior <lior@dotcore.co.il>