### PR TITLE
Fixed an issue causing wrong table data loads

### DIFF
--- a/src/components/vsTable/vsTable.vue
+++ b/src/components/vsTable/vsTable.vue
@@ -264,7 +264,7 @@ export default {
     loadData() {
       let max = Math.ceil(this.currentx * this.maxItems)
       let min = max - this.maxItems
-      if(!this.searchx) {
+      if(!this.searchx || this.sst) {
         this.datax = this.pagination ? this.getItems(min, max) : this.data || []
       } else {
         this.datax = this.pagination ? this.getItemsSearch(true ,min, max) : this.getItemsSearch(false ,min, max) || []


### PR DESCRIPTION
This issue occurs when the data is set and the search field is not empty and ssr=true.