### PR TITLE
add stylus and stylus loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Recent versions of **Firefox**, **Chrome**, **Edge**, **Opera** and **Safari**. 
 ``` bash
 # npm
 npm install vuesax
+npm install stylus stylus-loader
 ```
 
 ``` bash


### PR DESCRIPTION
In the documentation, it uses `<style lang="stylus">` so it is good to include it on the documentation at the first installation otherwise, it will throw an error that says, `Module not found` which is the `stylus` :)