### PR TITLE
Button Close check for vsPopup

### DIFF
--- a/src/components/vsPopup/vsPopup.vue
+++ b/src/components/vsPopup/vsPopup.vue
@@ -128,7 +128,7 @@ export default {
         if(event.target.className.indexOf('vs-popup--background')!=-1){
           this.$emit('update:active',false)
           this.$emit('close', false)
-        } else if(event.srcElement == this.$refs.btnclose.$el){
+        } else if(!this.buttonCloseHidden && event.srcElement == this.$refs.btnclose.$el){
           this.$emit('update:active',false)
           this.$emit('close', false)
         }


### PR DESCRIPTION
Fixes #631 

Click event inside vsPopup relies on a $ref that may not exist if the button-close-hidden-option is used.