### PR TITLE
Make vsPopup robust against unexpected events from content.

### DIFF
--- a/src/components/vsPopup/vsPopup.vue
+++ b/src/components/vsPopup/vsPopup.vue
@@ -125,7 +125,9 @@ export default {
     },
     close(event,con){
       if(con){
-        if(event.target.className.indexOf('vs-popup--background')!=-1){
+        if(event.target.className
+            && event.target.className.indexOf
+            && event.target.className.indexOf('vs-popup--background')!=-1){
           this.$emit('update:active',false)
           this.$emit('close', false)
         } else if(event.srcElement == this.$refs.btnclose.$el){


### PR DESCRIPTION
vsPopup content like vSelect (vue-select) can propagate events that don't have a string `className`, resulting in runtime exceptions when `indexOf()` is called on `className`. This change adds more checks to make vsPopup more robust.