### PR TITLE
Tabs component style fixed

### DIFF
--- a/src/components/vsTabs/vsTabs.vue
+++ b/src/components/vsTabs/vsTabs.vue
@@ -3,7 +3,6 @@
     :class="[`vs-tabs-${color}`,`vs-tabs-position-${position}`]"
     class="con-vs-tabs vs-tabs" >
     <div
-      :style="styleTabs"
       class="con-ul-tabs">
       <ul
         ref="ul"
@@ -13,6 +12,7 @@
           v-for="(child,index) in children"
           ref="li"
           :class="{'activeChild':childActive == index}"
+          :style="childActive == index ? styleTab : {}"
           class="vs-tabs--li"
           @mouseover="hover = true"
           @mouseout="hover = false">
@@ -81,7 +81,7 @@ export default {
     these:false,
   }),
   computed:{
-    styleTabs(){
+    styleTab(){
       return {
         color: _color.getColor(this.color,1),
       }

--- a/src/style/components/vsPagination.styl
+++ b/src/style/components/vsPagination.styl
@@ -2,6 +2,7 @@
   --color-pagination: rgb(240,240,240)
   --color-pagination-alpha: rgb(240,240,240, .5)
 .vs-pagination--input-goto
+  color: inherit
   padding: 8px
   border-radius: 5px
   border: 0px solid rgba(0,0,0,.2)

--- a/src/style/components/vsTabs.styl
+++ b/src/style/components/vsTabs.styl
@@ -106,6 +106,9 @@
 .vs-tabs--li
   display: block
   position relative
+  button
+    color inherit
+    font-family inherit
   button.vs-tabs--btn
     box-sizing: border-box
     display: block
@@ -209,16 +212,17 @@
 
 for colorx, i in $vs-colors
   .vs-tabs-{colorx}
-    button:not(:disabled)
-      &:hover
-        color: getColor(colorx, 1) !important
-    .activeChild
-      button
-        color: getColor(colorx, 1) !important
+    .con-ul-tabs
+      button:not(:disabled)
+        &:hover
+          color: getColor(colorx, 1) !important
+      .activeChild
+        button
+          color: getColor(colorx, 1) !important
 
-    .line-vs-tabs
-      background: linear-gradient(30deg, getColor(colorx, 1) 0%, getColor(colorx, .5) 100%) !important
-      box-shadow 0px 0px 8px 0px getColor(colorx, .4) !important
+      .line-vs-tabs
+        background: linear-gradient(30deg, getColor(colorx, 1) 0%, getColor(colorx, .5) 100%) !important
+        box-shadow 0px 0px 8px 0px getColor(colorx, .4) !important
 
 
 // vs-tab


### PR DESCRIPTION
If we have button inside tab content and if we hover over that button. Button's **color turns into primary**. This color is **relative to parent tab** component.
This is fixed in this PR.

Also font and color of tab header/title was **different** than what we use. So, new properties added.