### PR TITLE
divider text color issue fixed

### DIFF
--- a/src/components/vsDivider/vsDivider.vue
+++ b/src/components/vsDivider/vsDivider.vue
@@ -11,6 +11,7 @@
         'color': textColor
       }"
       class="vs-divider--text"
+      :class="textClass"
     >
       <template v-if="!icon">
         <slot/>
@@ -118,9 +119,8 @@ export default {
     },
     borderClass() {
       const classes = {}
-      if (_color.isColor(this.color)) {
-        classes[`vs-divider-border-${this.color}`] = true
-      }
+      let borderColor = _color.isColor(this.color) ? this.color : "default"
+      classes[`vs-divider-border-${borderColor}`] = true
       return classes
     },
     textColor() {
@@ -130,9 +130,9 @@ export default {
     },
     textClass() {
       const classes = {}
-      if (_color.isColor(this.color)) {
-        classes[`vs-divider-text-${this.color}`] = true
-      }
+      let textColor = _color.isColor(this.color) ? this.color : "default"
+      classes[`vs-divider-text-${textColor}`] = true
+
       return classes
     }
   }


### PR DESCRIPTION
divider component's text color was not changing according to divider color:
before:
![before](https://user-images.githubusercontent.com/47495003/62771686-6ce35800-babb-11e9-986e-cd5a9e39c7c4.png)
  
after:
![after](https://user-images.githubusercontent.com/47495003/62771693-71a80c00-babb-11e9-8585-a65df13fcd71.png)
