### PR TITLE
dropdown top height fix

### DIFF
--- a/src/components/vsDropDown/vsDropDown.vue
+++ b/src/components/vsDropDown/vsDropDown.vue
@@ -105,7 +105,7 @@ export default {
       let scrollTopx = window.pageYOffset || document.documentElement.scrollTop;
       if(this.$refs.dropdown.getBoundingClientRect().top + 300 >= window.innerHeight) {
         this.$nextTick(() => {
-          dropdownMenu.topx = (this.$refs.dropdown.getBoundingClientRect().top - dropdownMenu.$el.clientHeight - 15) + scrollTopx
+          dropdownMenu.topx = (this.$refs.dropdown.getBoundingClientRect().top - dropdownMenu.$el.clientHeight - 7) + scrollTopx
           dropdownMenu.notHeight = true
         });
 


### PR DESCRIPTION
Currently dropdown opening from top is **too high** which sometimes result in **bad UX** because of we **aren't able to go over options** sometimes.
So, dropdown now open close to element so it never disappear while going over options.