### PR TITLE
fix: dialog component outside click console error

### DIFF
--- a/src/functions/vsDialog/index.vue
+++ b/src/functions/vsDialog/index.vue
@@ -186,7 +186,7 @@ export default {
     handleClose(event,con){
       if(con){
         if(event.target.className.indexOf('vs-dialog-dark')!=-1 && this.type == 'alert'){
-          this.active = false
+          this.factive = false
           this.$emit('update:active',false)
         } else if (event.target.className.indexOf('vs-dialog-dark')!=-1) {
           this.rebound()

--- a/src/functions/vsDialog/index.vue
+++ b/src/functions/vsDialog/index.vue
@@ -18,7 +18,7 @@
             <span
               :style="styleAfter"
               class="after"/>
-            <h3>{{ title }} </h3>
+            <h3 class="dialog-title">{{ title }} </h3>
           </div>
           <vs-icon
             v-if="type=='alert'"

--- a/src/style/components/vsDialog.styl
+++ b/src/style/components/vsDialog.styl
@@ -150,6 +150,7 @@
 for colorx, i in $vs-colors
   .vs-dialog-{colorx}
     header
+      .dialog-title
         color: getColor(colorx, 1)
       .after
         background: getColor(colorx, 1)


### PR DESCRIPTION
Dialog component gives console error **if clicked outside**. This is was due to typo.
Please test it as I didn't tested it. Just basic testing.