### PR TITLE
Remove non-namespaced and undefined css classes

### DIFF
--- a/src/components/vsTable/vsTh.vue
+++ b/src/components/vsTable/vsTh.vue
@@ -1,6 +1,5 @@
 <template>
   <th
-    class="col-0 col"
     colspan="1"
     rowspan="1">
     <div class="vs-table-text">


### PR DESCRIPTION
This PR removes two undefined classes.

.col and .col-0 are common css class names. For instance they are used as classes in Bootstrap. Unless these classes are prefixed with "vs-", as in .vs-col and .vs-col-0, then they will collide with other CSS libraries. Also, I could not find anywhere in the .styl files where .col or .col-0 were defined - so they are not including styles that are native to Vuesax. If I want to add classes to the headers, then I could do so myself.