### PR TITLE
get all items if total is present

### DIFF
--- a/dist/vuesax.common.js
+++ b/dist/vuesax.common.js
@@ -9915,8 +9915,8 @@ function _typeof(obj) {
     },
     getItems: function getItems(min, max) {
       var items = [];
-      this.data.forEach(function (item, index) {
-        if (index >= min && index < max) {
+      this.data.forEach((item, index) => {
+        if (this.total || index >= min && index < max) {
           items.push(item);
         }
       });


### PR DESCRIPTION
On the true pagination, the data array contains only the elements of the current page.