### PR TITLE
Remove Math.round from vsSlider left calculation

### DIFF
--- a/src/components/vsSlider/vsSlider.vue
+++ b/src/components/vsSlider/vsSlider.vue
@@ -366,17 +366,11 @@ export default {
       let val = steps * lengthPerStep * (this.max - this.min) * 0.01 + this.min;
       val = this.stepDecimals ? this.toDecimal(val) : Math.round(val);
 
-      if (this.ticks) {
-        if (val > this.max) {
-          val = this.max;
-          this[this.two ? "leftTwo" : "leftx"] = 100;
-        } else {
-          this[this.two ? "leftTwo" : "leftx"] = steps * lengthPerStep;
-        }
+      if (val > this.max) {
+        val = this.max;
+        this[this.two ? "leftTwo" : "leftx"] = 100;
       } else {
-        this[this.two ? "leftTwo" : "leftx"] = Math.round(
-          steps * lengthPerStep
-        );
+        this[this.two ? "leftTwo" : "leftx"] = steps * lengthPerStep;
       }
 
       if (Array.isArray(this.value)) {


### PR DESCRIPTION
Hi! Nice component library, thanks for all your work on it 😄 

I have been using vs-slider and put my own numbers underneath the slider, something like:

    ---------------o---
    0  1  2  3  4  5  6

This works nicely, but I noticed that sometimes the slider's circle did not line up exactly with the tick mark. 

When inspecting CSS I saw that e.g for 5/6 the "left" property of the slider's circle was "83%", which is close but not quite the true value of 83.333333...%.

The rounding to integers can mean in this example the slider circle is not quite in the right position by a few pixels, which is noticable if you look carefully.

It seems to me that this conversion to integers comes from the use of Math.round() on line 377, so I removed this and simplified the surrounding lines to solve this issue.