### PR TITLE
Fix Input placeholder position

### DIFF
--- a/src/style/components/vsInput.styl
+++ b/src/style/components/vsInput.styl
@@ -64,7 +64,7 @@
   white-space: nowrap
   cursor text
   user-select none
-  top: 2px
+  top: -1px
   pointer-events: none
   &.small
     padding: 0.2rem


### PR DESCRIPTION
The Input component had a `top: 2px` property that causes the placeholder labels to not be centered. Changed to `top: -1px`.
This fixes #674 