### PR TITLE
Component Fixes & Improvement: vs-tabs & dropdown

### DIFF
--- a/src/components/vsDropDown/vsDropDown.vue
+++ b/src/components/vsDropDown/vsDropDown.vue
@@ -120,12 +120,16 @@ export default {
         || document.body.clientWidth;
 
 
-        if(dropdownMenu.$el.getBoundingClientRect && dropdownMenu.$el.getBoundingClientRect().left < 0) {
+        if(this.$refs.dropdown.getBoundingClientRect().left + dropdownMenu.$el.offsetWidth >= w - 25){
           this.rightx = true
-        }else {
-          this.rightx = false
         }
-        dropdownMenu.leftx = this.$refs.dropdown.getBoundingClientRect().left + (this.vsDropRight || this.rightx ? dropdownMenu.$el.clientWidth : this.$refs.dropdown.clientWidth );
+
+        if(this.$refs.dropdown.getBoundingClientRect().right < (dropdownMenu.$el.clientWidth + 25)) {
+          dropdownMenu.leftx = dropdownMenu.$el.clientWidth + 25
+          return
+        }
+        dropdownMenu.leftx = this.$refs.dropdown.getBoundingClientRect().left + (this.vsDropRight ? dropdownMenu.$el.clientWidth : this.$refs.dropdown.clientWidth );
+
       });
     },
     clickToogleMenu(evt){

--- a/src/components/vsTabs/vsTabs.vue
+++ b/src/components/vsTabs/vsTabs.vue
@@ -24,7 +24,7 @@
             @click="activeChild(index)"
             v-on="child.listeners">
             <vs-icon v-if="child.icon" :icon-pack="child.iconPack" :icon="child.icon" :color="color" class="vs-tabs--btn-icon"></vs-icon>
-            <span>{{ child.label }}</span>
+            <span v-if="child.label">{{ child.label }}</span>
           </button>
 
           <button @click="clickTag(child)" v-if="child.tag" class="vs-tabs--btn-tag">

--- a/src/style/components/vsTabs.styl
+++ b/src/style/components/vsTabs.styl
@@ -154,8 +154,8 @@
     padding-right: 0px !important
     font-size: .9rem
 
-.vs-tabs--btn-icon 
-  propWithDir(padding, right, 9px)
+.vs-tabs--btn-icon+span
+  propWithDir(padding, left, 9px)
 
 .vs-tabs-position-top
   .vs-tabs--ul


### PR DESCRIPTION
If we pass blank label in vs-tab icon still get padding on right - result in blank space between icons.
ffb5ac15d6cb5cab0312c2fb7e0c4c63f20f90a8 Fixes this issue