### PR TITLE
total pages now use the prop total if sst true

### DIFF
--- a/src/components/vsTable/vsTable.vue
+++ b/src/components/vsTable/vsTable.vue
@@ -150,7 +150,9 @@ export default {
   }),
   computed:{
     getTotalPages() {
-      return Math.ceil(this.data.length / this.maxItemsx)
+      let dataLength = !this.sst ? this.data.length : this.total;
+
+      return Math.ceil(dataLength / this.maxItemsx)
     },
     getTotalPagesSearch() {
       const search = this.normalize(this.searchx);


### PR DESCRIPTION
Paging does not work using SST property, page calculation was using total number of items on **data** prop and not **total** prop