### PR TITLE
New: Chip Transparent variant added + Button Router Error Event

### DIFF
--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -70,6 +70,10 @@ API:
     parameters: null
     description: Presence or absence of target property
     default: false
+  - name: routeErr
+    type: Event
+    parameters: error
+    description:  Triggers method when there's error in routing using button component
 ---
 
 # Buttons

--- a/docs/components/chip.md
+++ b/docs/components/chip.md
@@ -184,6 +184,75 @@ export default {
 
 </box>
 
+
+<box>
+
+## Transparent
+
+You can create chip which have transparent background using `transparent` prop.
+
+<vuecode md center>
+<div slot="demo">
+  <vs-chip transparent color="primary">
+    Basic Chip
+  </vs-chip>
+  <vs-chip transparent color="success">
+    <vs-avatar text="LD"/>
+    Avatar Text
+  </vs-chip>
+  <vs-chip transparent color="danger">
+    <vs-avatar />
+    Avatar Icon
+  </vs-chip>
+  <vs-chip transparent color="warning">
+    <vs-avatar src="https://randomuser.me/api/portraits/men/4.jpg"/>
+    Avatar Image
+  </vs-chip >
+  <vs-chip transparent closable color="dark">
+    Closable chip
+  </vs-chip>
+  <vs-chip transparent closable color="#24c1a0" close-icon="close">
+    <vs-avatar src="https://randomuser.me/api/portraits/men/16.jpg"/>
+    Closable chip
+  </vs-chip>
+</div>
+<div slot="code">
+
+```html
+<template lang="html">
+  <div slot="demo">
+    <vs-chip transparent color="primary">
+      Basic Chip
+    </vs-chip>
+    <vs-chip transparent color="success">
+      <vs-avatar text="LD"/>
+      Avatar Text
+    </vs-chip>
+    <vs-chip transparent color="danger">
+      <vs-avatar />
+      Avatar Icon
+    </vs-chip>
+    <vs-chip transparent color="warning">
+      <vs-avatar src="https://randomuser.me/api/portraits/men/4.jpg"/>
+      Avatar Image
+    </vs-chip >
+    <vs-chip transparent closable color="dark">
+      Closable chip
+    </vs-chip>
+    <vs-chip transparent closable color="#24c1a0" close-icon="close">
+      <vs-avatar src="https://randomuser.me/api/portraits/men/16.jpg"/>
+      Closable chip
+    </vs-chip>
+  </div>
+</template>
+```
+
+</div>
+</vuecode>
+
+</box>
+
+
 <box>
 
 ## Icon

--- a/docs/components/chip.md
+++ b/docs/components/chip.md
@@ -5,6 +5,11 @@ API:
    parameters: RGB, HEX, primary, success, danger, warning, dark
    description: Component color
    default: primary
+ - name: transparent
+   type: Boolean
+   parameters: true/false
+   description: Create chip with transparent background
+   default: false
  - name: closable
    type: Boolean
    parameters: null

--- a/src/components/vsButton/vsButton.vue
+++ b/src/components/vsButton/vsButton.vue
@@ -210,7 +210,7 @@ export default {
   methods:{
     isRTL(value) {
       if(this.$vs.rtl) {
-        return value 
+        return value
       }else {
         if(value === 'right') {
           return 'left'
@@ -221,7 +221,7 @@ export default {
       }
     },
     routerPush() {
-      this.$router.push(this.to)
+      this.$router.push(this.to).catch(err => { this.$emit("routeErr", err) })
     },
     is(which){
       let type = this.type

--- a/src/components/vsChip/vsChip.vue
+++ b/src/components/vsChip/vsChip.vue
@@ -5,7 +5,8 @@
       `vs-chip-${color}`,
       {
         'closable': closable,
-        'con-color': color
+        'con-color': color,
+        'bg-transparent': transparent
       }
     ]"
     class="con-vs-chip">
@@ -65,12 +66,19 @@ export default {
       type:String,
       default:'clear',
     },
+    transparent: {
+      type: Boolean,
+      default: false
+    }
   },
   computed:{
     styleChip () {
+      const background = this.transparent ? _color.getColor(this.color,.15) : _color.getColor(this.color,1)
+      const color = this.transparent ? _color.getColor(this.color,1) : this.color?'rgba(255,255,255,.9)':'rgba(0,0,0,.7)'
+
       return {
-        background: _color.getColor(this.color,1),
-        color: this.color?'rgba(255,255,255,.9)':'rgba(0,0,0,.7)'
+        background: background,
+        color: color
       }
     },
     eliminado(){

--- a/src/components/vsInput/vsInput.vue
+++ b/src/components/vsInput/vsInput.vue
@@ -64,7 +64,7 @@
           :class="{'icon-before':iconAfter}">
           <vs-icon
             :class="{'icon-before':iconAfter}"
-            :valIconPack="valIconPack"
+            :iconPack="valIconPack"
             :icon="getIcon"
           ></vs-icon>
         </span>

--- a/src/components/vsTabs/vsTabs.vue
+++ b/src/components/vsTabs/vsTabs.vue
@@ -175,6 +175,7 @@ export default {
         const update = () => {
           this.leftx = elem.offsetLeft
           this.widthx = elem.offsetWidth
+          this.topx = (elem.offsetHeight + (elem.getBoundingClientRect().top - this.$refs.ul.getBoundingClientRect().top))
         }
         if (!initialAnimation) {
           update()

--- a/src/style/components/vsChip.styl
+++ b/src/style/components/vsChip.styl
@@ -31,7 +31,7 @@
     .material-icons
       margin-top: 0px
       font-size: .8rem
-  &.transparent
+  &.bg-transparent
     font-weight: 500
 
 .vs-chip--close
@@ -59,7 +59,7 @@
   propWithDir(margin, left, 10px)
 
 for colorx, i in $vs-colors
-  .vs-chip-{colorx}:not(.transparent)
+  .vs-chip-{colorx}:not(.bg-transparent)
     background: getColor(colorx, 1)
   .vs-chip-{colorx}.bg-transparent
     background: getColor(colorx, .15)

--- a/src/style/components/vsChip.styl
+++ b/src/style/components/vsChip.styl
@@ -31,6 +31,8 @@
     .material-icons
       margin-top: 0px
       font-size: .8rem
+  &.transparent
+    font-weight: 500
 
 .vs-chip--close
   width: 20px
@@ -57,8 +59,11 @@
   propWithDir(margin, left, 10px)
 
 for colorx, i in $vs-colors
-  .vs-chip-{colorx}
+  .vs-chip-{colorx}:not(.transparent)
     background: getColor(colorx, 1)
+  .vs-chip-{colorx}.bg-transparent
+    background: getColor(colorx, .15)
+    color: getColor(colorx, 1)
 
 
 // con - chips

--- a/src/style/components/vsCollapse.styl
+++ b/src/style/components/vsCollapse.styl
@@ -1,6 +1,5 @@
 .vs-collapse
   transition: all .3s ease;
-  cursor: pointer;
   border-radius: 8px
   // box-shadow: 0px 2px 12px 0px rgba(0,0,0,.05)
   padding: 10px
@@ -52,6 +51,7 @@
 
 .vs-collapse-item
   border-bottom: 1px solid rgba(0,0,0,.04)
+  cursor: pointer;
   transition: all .25s ease
   &.open-item
     .con-content--item

--- a/src/style/components/vsRadio.styl
+++ b/src/style/components/vsRadio.styl
@@ -65,6 +65,10 @@
       .vs-radio--borde
         transform: scale(1.1);
   &:disabled
+    + .vs-radio,
+    + .vs-radio + .vs-radio--label
+      pointer-events: none;
+      cursor: default;
     + .vs-radio
       opacity: .4;
       .vs-radio--circle

--- a/src/style/components/vsTabs.styl
+++ b/src/style/components/vsTabs.styl
@@ -91,6 +91,7 @@
     justify-content flex-end
   &.ul-tabs-fixed
     justify-content space-between
+    flex-wrap: nowrap !important
     li
       width 100%
 

--- a/src/style/components/vsTabs.styl
+++ b/src/style/components/vsTabs.styl
@@ -160,6 +160,7 @@
 .vs-tabs-position-top
   .vs-tabs--ul
     display: flex
+    flex-wrap: wrap
 .vs-tabs-position-bottom
   .vs-tabs--ul
     display: flex

--- a/src/style/components/vsUpload.styl
+++ b/src/style/components/vsUpload.styl
@@ -24,6 +24,7 @@
     opacity: 0
     pointer-events: none
     user-select: none
+    display: none
   input
     position: absolute
     width: 100%;


### PR DESCRIPTION
New chip variant added: **Transparent**

This is how it looks like.
![chip-transparent](https://user-images.githubusercontent.com/47495003/68185735-494f8100-ffc8-11e9-97c1-905233c0a50d.png)

@luisDanielRoviraContreras I hope you like this variant, please review & merge. As this is popular variant and loved by almost all devs.