### PR TITLE
vsTable - sort is not working when pagination is disabled fix

### DIFF
--- a/src/components/vsTable/vsTable.vue
+++ b/src/components/vsTable/vsTable.vue
@@ -257,7 +257,7 @@ export default {
       let min = max - this.maxItemsx
 
       if(!this.searchx || this.sst) {
-        this.datax = this.pagination ? this.getItems(min, max) : this.data || [];
+        this.datax = this.pagination ? this.getItems(min, max) : this.sortItems(this.data) || [];
       } else {
         this.datax = this.pagination ? this.getItemsSearch(true ,min, max) : this.getItemsSearch(false ,min, max) || []
       }


### PR DESCRIPTION
According to the tip given by @jsinhSolanki in https://github.com/lusaxweb/vuesax/pull/619 this PR fixes sorting when pagination is not used in vsTable.