### PR TITLE
Adding 'vs-dialog-accept-button' and 'vs-dialog-cancel-button' to vsDialog

### DIFF
--- a/src/functions/vsDialog/index.vue
+++ b/src/functions/vsDialog/index.vue
@@ -35,11 +35,13 @@
         <!-- footer buttons -->
         <footer v-if="buttonsHidden?false:isPrompt||type=='confirm'">
           <vs-button
+            class="vs-dialog-accept-button"
             :disabled="isValid=='none'?false:!isValid"
             :color="color"
             :type="buttonAccept"
             @click="acceptDialog">{{ acceptText }}</vs-button>
           <vs-button
+            class="vs-dialog-cancel-button"
             :text-color="'rgba(0,0,0,.5)'"
             :type="buttonCancel"
             @click="cancelClose">{{ cancelText }}</vs-button>
@@ -47,6 +49,7 @@
 
         <footer v-if="type=='alert'&&!isPrompt" >
           <vs-button
+            class="vs-dialog-accept-button"
             :color="color"
             :type="buttonAccept"
             @click="acceptDialog">{{ acceptText }}</vs-button>


### PR DESCRIPTION
Hello,

i'm proposing to add two css classes to accept and cancel buttons in vs-dialog :
`vs-dialog-accept-button`
and
`vs-dialog-cancel-button`

the purpose is to allow easier custom styling of those buttons.

for example, we can now style buttons :
```
.vs-dialog .vs-dialog-cancel-button {
    height: 80px;
    color: red;
}
```

thanks.