### PR TITLE
fix [#532] correct set checkbox value at Safari

### DIFF
--- a/src/components/vsCheckBox/vsCheckBox.vue
+++ b/src/components/vsCheckBox/vsCheckBox.vue
@@ -68,7 +68,7 @@ export default {
     },
     listeners(){
       return {
-        ...this.$listeners,
+        // ...this.$listeners,
         change: (evt) => {
           this.toggleValue(evt)
         },

--- a/src/components/vsCheckBox/vsCheckBox.vue
+++ b/src/components/vsCheckBox/vsCheckBox.vue
@@ -69,12 +69,12 @@ export default {
     listeners(){
       return {
         ...this.$listeners,
-        // change: (evt) => {
-        //   this.toggleValue(evt)
-        // },
-        input: (evt) => {
+        change: (evt) => {
           this.toggleValue(evt)
-        }
+        },
+        // input: (evt) => {
+        //   this.toggleValue(evt)
+        // }
       }
     },
     isChecked(){


### PR DESCRIPTION
Safari don't have `input listener` for input with checkbox type so you need to use `change listener` for toggle value.