### PR TITLE
IOS mobile device uncheck small checkbox UI fixed + Few Upgrades

### DIFF
--- a/src/components/vsChip/vsChip.vue
+++ b/src/components/vsChip/vsChip.vue
@@ -6,7 +6,7 @@
       {
         'closable': closable,
         'con-color': color,
-        'bg-transparent': transparent
+        'bg-chip-transparent': transparent
       }
     ]"
     class="con-vs-chip">

--- a/src/components/vsChip/vsChip.vue
+++ b/src/components/vsChip/vsChip.vue
@@ -19,6 +19,7 @@
     <button
       v-if="closable"
       class="btn-close vs-chip--close"
+      type="button"
       @click="closeChip">
       <vs-icon
         :icon-pack="iconPack"

--- a/src/components/vsTabs/vsTab.vue
+++ b/src/components/vsTabs/vsTab.vue
@@ -39,6 +39,10 @@ export default {
   watch: {
     label(val) {
       this.$parent.children[this.id].label = val;
+    },
+    '$attrs' (val) {
+      console.log('chnaged attr')
+      this.$parent.children[this.id].attrs = val;
     }
   },
   mounted(){

--- a/src/style/components/vsCheckBox.styl
+++ b/src/style/components/vsCheckBox.styl
@@ -88,11 +88,10 @@
 
 for colorx, i in $vs-colors
   .vs-checkbox-{colorx}
-    .vs-checkbox--check
-      background: getColor(colorx, 1)
     .vs-checkbox
       border: 2px solid rgb(180, 180, 180)
     input
       &:checked
         & + .vs-checkbox
           border: 2px solid getColor(colorx, 1) !important
+          background: getColor(colorx, 1)

--- a/src/style/components/vsChip.styl
+++ b/src/style/components/vsChip.styl
@@ -31,7 +31,7 @@
     .material-icons
       margin-top: 0px
       font-size: .8rem
-  &.bg-transparent
+  &.bg-chip-transparent
     font-weight: 500
 
 .vs-chip--close
@@ -59,9 +59,9 @@
   propWithDir(margin, left, 10px)
 
 for colorx, i in $vs-colors
-  .vs-chip-{colorx}:not(.bg-transparent)
+  .vs-chip-{colorx}:not(.bg-chip-transparent)
     background: getColor(colorx, 1)
-  .vs-chip-{colorx}.bg-transparent
+  .vs-chip-{colorx}.bg-chip-transparent
     background: getColor(colorx, .15)
     color: getColor(colorx, 1)
 


### PR DESCRIPTION
If we use small checkbox in ios mobile devices. 
Uncheck checkbox give square on top of checkbox, it requires some CSS changes which I have done in this commit.
@luisDanielRoviraContreras Review as you get time to check. I have tested it on iphone 6.