### PR TITLE
collapse for ssr

### DIFF
--- a/src/components/vsCollapse/vsCollapseItem.vue
+++ b/src/components/vsCollapse/vsCollapseItem.vue
@@ -12,7 +12,9 @@
       <span
         v-if="!notArrow"
         class="icon-header vs-collapse-item--icon-header">
-        <vs-icon :icon-pack="iconPack"  :icon="iconArrow" >
+        <vs-icon 
+          :icon-pack="iconPack" 
+          :icon="iconArrow" >
         </vs-icon>
       </span>
     </header>
@@ -56,9 +58,15 @@ export default {
       default: 'material-icons',
       type: String
     },
+    sst: {
+      default: false,
+      type: Boolean
+    }
   },
   data:() => ({
-    maxHeight: '0px'
+    maxHeight: '0px',
+    // only used for sst
+    dataReady: false
   }),
   computed:{
     accordion() {
@@ -76,18 +84,23 @@ export default {
   watch:{
     maxHeight() {
       this.$parent.emitChange()
+    },
+    ready(newVal, oldVal) {
+      if (oldVal != newVal && newVal) {
+        this.initMaxHeight()
+      }
     }
   },
   mounted () {
     window.addEventListener('resize', this.changeHeight)
-    let maxHeightx = this.$refs.content.scrollHeight
+    const maxHeightx = this.$refs.content.scrollHeight
     if(this.open) {
       this.maxHeight = `${maxHeightx}px`
     }
   },
   methods:{
     changeHeight () {
-      let maxHeightx = this.$refs.content.scrollHeight
+      const maxHeightx = this.$refs.content.scrollHeight
       if(this.maxHeight != '0px') {
         this.maxHeight = `${maxHeightx}px`
       }
@@ -101,7 +114,19 @@ export default {
         this.$parent.closeAllItems(this.$el)
       }
 
-      let maxHeightx = this.$refs.content.scrollHeight
+      if (this.sst && !this.dataReady) {
+        this.$emit('fetch', {
+          done: () => {
+            this.initMaxHeight();
+            this.dataReady = true
+          }
+        })
+      } else {
+        this.initMaxHeight()
+      }
+    },
+    initMaxHeight() {
+      const maxHeightx = this.$refs.content.scrollHeight
       if(this.maxHeight == '0px') {
         this.maxHeight = `${maxHeightx}px`
       } else {


### PR DESCRIPTION
I created this pull request because I'm fetching the data that appears in the CollapseItems from an api and I want to fetch it that moment when the user opens the item. Because I cannot predict the height of the resulting content and the CollapseItem is setting a max-height depending on the current height.

This screenshot illustrates the issue with server side rendered data:
<img width="387" alt="Bildschirmfoto 2019-12-15 um 14 08 03_990" src="https://user-images.githubusercontent.com/22933507/70992223-7b74f800-20c9-11ea-8dac-39f2f23130a3.png">

This is why I want to introduce the property `sst` for the `vsCollapseItem` component. Add this and pass a `@fetch` event handler. The component will then run the fetch event on the first time the user opens the item. Because the component needs a feedback that the data is ready now and it can set the maxHeight now, I pass a callback function. Be sure to run it as shown in the following example.

```
<template>
    <vs-collapse>
     <vs-collapse-item :sst="true" @fetch="fetchData">
       <div slot="header">
         Collapse item
       </div>

       {{ data }}
     </vs-collapse-item>
 </vs-collapse>
</template>
<script>
    export default {
        data() {
            data: null
        },
        methods: {
            fetchData({ done }) {
                fetch({..}).then(resp => {
                    this.data = resp.data

                    // Do this to signalize the data is ready!
                    done()
                }
            }
        }
    }
</script>
```

Maybe I come up with something better - or you do. I was in a bit of a hurry. But feedback of any kind is very welcome!