### PR TITLE
Calculate pagination based on total items prop

### DIFF
--- a/src/components/vsTable/vsTable.vue
+++ b/src/components/vsTable/vsTable.vue
@@ -156,7 +156,7 @@ export default {
   }),
   computed:{
     getTotalPages() {
-      return Math.ceil(this.data.length / this.maxItemsx)
+      return Math.ceil(this.total / this.maxItemsx)
     },
     getTotalPagesSearch() {
       return Math.ceil(this.queriedResults.length / this.maxItems)


### PR DESCRIPTION
If you are using sst, you'll get fewer items in data than in the total prop.

For example you could get 1 item in the data array but 100 items as total.