### PR TITLE
fix issue #770 vsSelect stop working, closest() is not working

### DIFF
--- a/src/components/vsSelect/vsSelect.vue
+++ b/src/components/vsSelect/vsSelect.vue
@@ -437,8 +437,9 @@ export default {
       });
     },
     clickBlur(event) {
-      let closestx = event.target.closest(".vs-select--options");
-
+      let closestx = event.target.getElementsByClassName(
+        "vs-select--options"
+      )[0];
       if (!closestx) {
         this.closeOptions();
         if (this.autocomplete) {


### PR DESCRIPTION
event.target.closest() always returns 'null' , and the select options are closed

Issue: https://github.com/lusaxweb/vuesax/issues/770