### PR TITLE
Update vsTab.vue

### DIFF
--- a/src/components/vsTabs/vsTab.vue
+++ b/src/components/vsTabs/vsTab.vue
@@ -1,7 +1,7 @@
 <template lang="html">
   <transition :name="invert?vertical?'fade-tab-vertical-invert':'fade-tab-invert':vertical?'fade-tab-vertical':'fade-tab'">
     <div
-      v-if="active"
+      v-show="active"
       class="con-tab vs-tabs--content">
       <slot/>
     </div>


### PR DESCRIPTION
Change v-if to v-show is necessary to preserve child component instance when tab changes.