### PR TITLE
Textarea height issues and resize property

### DIFF
--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -25,6 +25,11 @@ API:
    parameters: null
    description: Set the height of the textarea
    default: null
+ - name: resize
+   type: Boolean
+   parameters: null
+   description: Determine if textarea is resizable
+   default: true
 ---
 
 # Textarea

--- a/src/components/vsTextarea/vsTextarea.vue
+++ b/src/components/vsTextarea/vsTextarea.vue
@@ -12,7 +12,8 @@
       :value="value"
       v-bind="$attrs"
       class="vs-textarea"
-      v-on="listeners">
+      v-on="listeners"
+      :style="textareaStyle">
     </textarea>
 
     <div
@@ -54,6 +55,10 @@ export default {
     width:{
       default:null,
       type: String
+    },
+    resize:{
+      default: true,
+      type: Boolean
     }
   },
   data:()=>({
@@ -61,12 +66,20 @@ export default {
   }),
   computed:{
     style() {
-      let style = {}
+      const style = {}
       style.border = `1px solid ${this.isFocus?_color.getColor(this.color,1):'rgba(0, 0, 0,.08)'}`
-      style.height = this.height
+      //style.height = this.height
       style.width = this.width
 
       return style
+    },
+    textareaStyle() {
+      const style = {};
+      style.height = this.height;
+      if (!this.resize) {
+        style.resize = 'none';
+      }
+      return style;
     },
     listeners() {
       return {

--- a/src/style/components/vsTextarea.styl
+++ b/src/style/components/vsTextarea.styl
@@ -38,7 +38,7 @@
   min-width 100%
   background: transparent
   &:focus
-    resize: auto !important
+    resize: auto
     ~
       .count
         opacity 1


### PR DESCRIPTION
The textarea height was out of sync with the height of the box when the height prop was used.
![Mar-28-2020 21-53-11](https://user-images.githubusercontent.com/22933507/77833551-8b778b80-713e-11ea-8472-400569cdef50.gif)

Additionally, I added the `resize` prop to be able to disable resizability of a textarea.