### PR TITLE
disableAnimation prop and border to vsButton

### DIFF
--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -74,6 +74,10 @@ API:
     type: Event
     parameters: error
     description:  Triggers method when there's error in routing using button component
+  - name: disableAnimation
+    type: Boolean
+    description: Disables animation effect on click
+    default: false
 ---
 
 # Buttons

--- a/src/components/vsButton/vsButton.vue
+++ b/src/components/vsButton/vsButton.vue
@@ -118,6 +118,10 @@ export default {
     button:{
       default:'button',
       type:String
+    },
+    disableAnimation:{
+      default:false,
+      type:Boolean
     }
   },
   data:()=>({
@@ -247,7 +251,8 @@ export default {
     },
     clickButton(event){
       this.$emit('click',event)
-      if(this.isActive){
+
+      if(this.disableAnimation || this.isActive){
         return
       }
       if(this.to){

--- a/src/style/components/vsButton.styl
+++ b/src/style/components/vsButton.styl
@@ -105,13 +105,13 @@
 for colorx, i in $vs-colors
 
   .vs-button-{colorx}
+    border: 1px solid getColor(colorx)
     &.vs-button-filled //type filled
       // background: $vs-colors[colorx]
       background: getColor(colorx) !important
       &:hover
         box-shadow: 0px 8px 25px -8px getColor(colorx)
     &.vs-button-border,&.vs-button-flat //type border
-     border: 1px solid getColor(colorx)
      background: transparent !important
      color: getColor(colorx)
      .vs-button--text


### PR DESCRIPTION
For my application I needed a design where I can have a vsButton in the style of the bordered buttons without the effect you get when you click it. I wanted to customize the behavior on click myself. In my case I wanted to change the style of the button from bordered & dark to filled & primary.

To do this I added the following:
- `disableAnimation` that will disable a click animation (useful on type border & flat)
- Border on filled buttons. There will be no visible difference! But it ensures a filled button has the same width as a border or flat button, which was necessary for a smooth transition between those types).