### PR TITLE
feat: add DocSearch as recommended by vuepress

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -108,6 +108,10 @@ module.exports = {
     ]
   },
   themeConfig: {
+    algolia: {
+      apiKey: '1e7de593e1699e48c6dabbe77da817c6',
+      indexName: 'vuesax'
+    },
     // Assumes GitHub. Can also be a full GitLab url.
     repo: 'lusaxweb/vuesax',
     // Customising the header label


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Vuepress](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on vuejs for example](https://vuejs.org/).

This PR will add DocSearch to the documentation website. It will allow a user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.