### PR TITLE
Fix getTotalPages when using SST and total props (fix #772)

### DIFF
--- a/src/components/vsTable/vsTable.vue
+++ b/src/components/vsTable/vsTable.vue
@@ -156,7 +156,8 @@ export default {
   }),
   computed:{
     getTotalPages() {
-      return Math.ceil(this.data.length / this.maxItemsx)
+      const totalLength = this.sst && this.total ? this.total : this.data.length
+      return Math.ceil(totalLength / this.maxItemsx)
     },
     getTotalPagesSearch() {
       return Math.ceil(this.queriedResults.length / this.maxItems)


### PR DESCRIPTION
vsTable currently ignores the 'total' prop entirely and uses the data length to calculate number of pages
Added statement to check if SSR and total props are defined before returning value