### PR TITLE
Fix vsTable 'select all' checkbox (Fix #773, #743, #727)

### DIFF
--- a/src/components/vsTable/vsTable.vue
+++ b/src/components/vsTable/vsTable.vue
@@ -37,7 +37,7 @@
                     :icon="isCheckedLine ? 'remove' : 'check'"
                     :checked="isCheckedMultiple"
                     size="small"
-                    @click="changeCheckedMultiple"/>
+                    @change="changeCheckedMultiple"/>
                 </span>
               </th>
               <slot name="thead"></slot>


### PR DESCRIPTION
vsTable select all checkbox doesn't trigger
Changed vsTable checkbox event from 'click' to 'change'