### PR TITLE
fix #770 vsSelect open/close at the same time

### DIFF
--- a/src/components/vsSelect/vsSelect.vue
+++ b/src/components/vsSelect/vsSelect.vue
@@ -437,7 +437,9 @@ export default {
       });
     },
     clickBlur(event) {
-      let closestx = event.target.closest(".vs-select--options");
+      let closestx = event.target == document.body
+        ? event.target.getElementsByClassName("vs-select--options").item(0)
+        : event.target.closest(".vs-select--options");
 
       if (!closestx) {
         this.closeOptions();


### PR DESCRIPTION
it's adopted from @okrulik 's comment in #770.
it should be considered a workaround, not a proper fix.

somehow, `clickBlur` method would randomly capture click event from \<body\>, closest method would always return null, make vsSelect open/close at the same time.