### PR TITLE
type="button"

### DIFF
--- a/src/components/vsSlider/vsSlider.vue
+++ b/src/components/vsSlider/vsSlider.vue
@@ -13,6 +13,7 @@
       ref="slider"
       :disabled="disabled"
       class="vs-slider"
+      type="button"
       @click="clickSlider($event),actived = true">
       <span
         :style="styleLineOne"
@@ -45,6 +46,7 @@
       }"
       :style="styleCircle"
       class="vs-circle-slider vs-circles-slider vs-slider--circles vs-slider--circle"
+      type="button"
       @touchstart="activeFocus($event),actived = true"
       @mousedown="activeFocus($event),actived = true">
       <span
@@ -73,6 +75,7 @@
       }"
       :style="styleCircleTwo"
       class="vs-circle-slider-two vs-circles-slider vs-slider--circles vs-slider--circle-two"
+      type="button"
       @touchstart="activeFocus($event),two = true,actived = true"
       @mousedown="activeFocus($event),two = true,actived = true">
 


### PR DESCRIPTION
This PR adds type="button" to all HTML5 <button> on the slider component to prevent form submit.

[As stated in W3C documentation](https://www.w3.org/TR/2011/WD-html5-20110525/the-button-element.html#the-button-element) if "type" attribute is missing declaration, the button will act as a submit form button.

I've came across this issue, as reported in #813 also.
