### PR TITLE
Tooltip improvements and fix tooltip not opening

### DIFF
--- a/src/components/vsTooltip/vsTooltip.vue
+++ b/src/components/vsTooltip/vsTooltip.vue
@@ -49,11 +49,12 @@ export default {
     active: {
       default: true,
       type: [Boolean]
-    }
+    },
+    value: Boolean,
   },
   data:()=>({
     cords:{},
-    activeTooltip:false,
+    activeTooltip:this.value,
     widthx: 'auto',
     positionx: null,
     noneAfter: false
@@ -66,6 +67,16 @@ export default {
         transitionDelay: this.activeTooltip?this.delay:'0s',
         background:_color.getColor(this.color,1),
         width: this.widthx
+      }
+    }
+  },
+  watch: {
+    value(val) {
+      this.activeTooltip = val
+    },
+    activeTooltip(val) {
+      if (this.value !== val) {
+        this.$emit('input', val)
       }
     }
   },

--- a/src/components/vsTooltip/vsTooltip.vue
+++ b/src/components/vsTooltip/vsTooltip.vue
@@ -52,13 +52,15 @@ export default {
     },
     value: Boolean,
   },
-  data:()=>({
-    cords:{},
-    activeTooltip:this.value,
-    widthx: 'auto',
-    positionx: null,
-    noneAfter: false
-  }),
+  data() {
+    return {
+      cords:{},
+      activeTooltip: this.value,
+      widthx: 'auto',
+      positionx: null,
+      noneAfter: false
+    };
+  },
   computed:{
     style(){
       return {

--- a/src/components/vsTooltip/vsTooltip.vue
+++ b/src/components/vsTooltip/vsTooltip.vue
@@ -88,6 +88,11 @@ export default {
       this.activeTooltip = false
     }
   },
+  beforeDestroy() {
+      if(this.$refs.vstooltip) {
+        utils.removeBody(this.$refs.vstooltip)
+      }
+  },
   methods:{
     mouseenterx(){
       if(this.active) {

--- a/src/components/vsTooltip/vsTooltip.vue
+++ b/src/components/vsTooltip/vsTooltip.vue
@@ -73,8 +73,7 @@ export default {
     // utils.insertBody(this.$refs.vstooltip)
   },
   updated() {
-    let nodes = this.$refs.convstooltip.childNodes.length
-    if (nodes === 1) {
+    if (!this.$slots.default) {
       this.activeTooltip = false
     }
   },

--- a/src/components/vsTooltip/vsTooltip.vue
+++ b/src/components/vsTooltip/vsTooltip.vue
@@ -11,8 +11,10 @@
         :class="[`vs-tooltip-${positionx || position}`,`vs-tooltip-${color}`, {'after-none': noneAfter}]"
         :style="style"
         class="vs-tooltip">
-        <h4 v-if="title">{{ title }}</h4>
-        {{ text }}
+        <slot name="content">
+          <h4 v-if="title">{{ title }}</h4>
+          {{ text }}
+        </slot>
       </div>
     </transition>
     <slot></slot>

--- a/src/components/vsTooltip/vsTooltip.vue
+++ b/src/components/vsTooltip/vsTooltip.vue
@@ -89,7 +89,7 @@ export default {
     }
   },
   beforeDestroy() {
-      if(this.$refs.vstooltip) {
+      if(this.$refs.vstooltip && this.activeTooltip) {
         utils.removeBody(this.$refs.vstooltip)
       }
   },


### PR DESCRIPTION
Added a slot for the content of the tooltip

This allows for more complex tooltips to be created

```html
<vs-tooltip>
  <template #content>
    <div>Render some <strong>HTML</strong></div>
    <vs-avatar text="and components"/>
  </template>
  <vs-btn>Test</vs-btn>
</vs-tooltip>
```

Added support for v-model to change/retrieve the state of the tooltip

Fixes #435, #647, #490 

Also fixed the logic of the updated hook that would just make the tooltip not show if it contained only one element
Now it will correctly close when the element inside is destroyed (which was the intention of this function)