### PR TITLE
Added subtitle slot in vs-popup

### DIFF
--- a/src/components/vsPopup/vsPopup.vue
+++ b/src/components/vsPopup/vsPopup.vue
@@ -20,6 +20,7 @@
           class="vs-popup--header">
           <div class="vs-popup--title">
             <h3>{{ title }}</h3>
+            <slot name="subtitle" />
           </div>
           <vs-icon
             v-if="!buttonCloseHidden"


### PR DESCRIPTION
Added subtitle slot for the title of the popup

This allows for more complex title in popup to be created

```vue
<vs-popup
  title="some title"
  :active="isShow"
>
  <template slot="subtitle">
    <p class="vs-popup--subtitle">
      some subtitle
      <i class="fi-some-icon" />
    </p>
  </template>
....
</vs-popup>
```