### PR TITLE
[VSTable] Fix expand slot components are not in the vue tree

### DIFF
--- a/src/components/vsTable/vsTd.vue
+++ b/src/components/vsTable/vsTd.vue
@@ -63,9 +63,7 @@ export default {
         let tr = evt.target.closest('tr')
         if(!this.activeEdit) {
           let trx = Vue.extend(trExpand);
-          let instance = new trx();
-          instance.$props.colspan = 5
-          instance.$props.close = true
+          let instance = new trx({parent: this, propsData: {colspan: this.$parent.colspan, close: true}});
           instance.$slots.default = this.$slots.edit
           instance.vm = instance.$mount();
           instance.$on('click', this.close)

--- a/src/components/vsTable/vsTr.vue
+++ b/src/components/vsTable/vsTr.vue
@@ -108,9 +108,7 @@ export default {
       } else {
         tr.classList.add('tr-expandedx')
         let trx = Vue.extend(trExpand);
-        let instance = new trx();
-        instance.$props.colspan = this.colspan
-        instance.$slots.default = this.$slots.expand
+        let instance = new trx({parent: this, propsData: {colspan: this.colspan}});
         instance.vm = instance.$mount();
         var newTR = document.createElement('tr').appendChild(instance.vm.$el);
         this.insertAfter(tr, newTR)


### PR DESCRIPTION
This makes any vue global property inaccessible within the expand slot (eg: try accessing $store within the expand slot and you'll get undefined, it also makes them invisible in the vue devtools)

With this PR $store now works correctly in the expand slot and the expand components are also visible in devtools