### PR TITLE
[Bug] Fix VsButton throwing error on $nextTick

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,0 @@
-# Vuesax clone
-Made for solving bugs or improve things that we need in our projects.
-
-## TODOs: detected bugs or improvements
-- Fix button in vsUpload has no type="button" so it causes submit if inside a form: https://github.com/lusaxweb/vuesax/blob/master/src/components/vsUpload/vsUpload.vue#L28.
-- VsButton throws an error `Console error: Error in nextTick: “TypeError: Cannot read property ‘clientWidth’ of undefine”` because it triggers on click a `this.$nextTick(callback)` and element may not exist when `callback` is executed (for example, when closing dialogs or navigating between router views): https://github.com/lusaxweb/vuesax/commit/a6506834d90b8b96ece5bcc4554e212277b75318.
-- Update dependencies.
-- Fix component vsUpload does not work on iOS 13.7 on iPhone 7 (still working on it).

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,8 @@
+# Vuesax clone
+Made for solving bugs or improve things that we need in our projects.
+
+## TODOs: detected bugs or improvements
+- Fix button in vsUpload has no type="button" so it causes submit if inside a form: https://github.com/lusaxweb/vuesax/blob/master/src/components/vsUpload/vsUpload.vue#L28.
+- VsButton throws an error `Console error: Error in nextTick: “TypeError: Cannot read property ‘clientWidth’ of undefine”` because it triggers on click a `this.$nextTick(callback)` and element may not exist when `callback` is executed (for example, when closing dialogs or navigating between router views): https://github.com/lusaxweb/vuesax/commit/a6506834d90b8b96ece5bcc4554e212277b75318.
+- Update dependencies.
+- Fix component vsUpload does not work on iOS 13.7 on iPhone 7 (still working on it).

--- a/src/components/vsButton/vsButton.vue
+++ b/src/components/vsButton/vsButton.vue
@@ -238,7 +238,7 @@ export default {
     blurButton(event){
       this.$emit('blur',event)
       this.$nextTick(() => {
-        if (this._isBeingDestroyed || this._isDestroyed ) {
+        if (this._isBeingDestroyed || this._isDestroyed){
           return
         }
 
@@ -255,7 +255,7 @@ export default {
     clickButton(event){
       this.$emit('click', event)
       this.$nextTick(() => {
-        if (this._isBeingDestroyed || this._isDestroyed ) {
+        if (this._isBeingDestroyed || this._isDestroyed){
           return
         }
         if(this.isActive){

--- a/src/components/vsButton/vsButton.vue
+++ b/src/components/vsButton/vsButton.vue
@@ -238,6 +238,10 @@ export default {
     blurButton(event){
       this.$emit('blur',event)
       this.$nextTick(() => {
+        if (this._isBeingDestroyed || this._isDestroyed ) {
+          return
+        }
+
         if(this.type == 'border' || this.type == 'flat'){
           this.opacity = 0
           setTimeout( () => {
@@ -246,11 +250,14 @@ export default {
           this.isActive = false
         }
       });
-      
+
     },
     clickButton(event){
       this.$emit('click', event)
       this.$nextTick(() => {
+        if (this._isBeingDestroyed || this._isDestroyed ) {
+          return
+        }
         if(this.isActive){
           return
         }
@@ -301,7 +308,7 @@ export default {
           }, this.time * 1100)
         }
       });
-      
+
 
     },
     isColor(){


### PR DESCRIPTION
**Bug**: Sometimes when we click a **VsButton** it throws the next error: `Console error: Error in nextTick: “TypeError: Cannot read property ‘clientWidth’ of undefine”`. That is caused because click function executes a `this.$nextTick()` and **VsButton** may not exist in next tick (eg: because of transitions between routes in SPAs or when closing a VsDialog).

It is reproducible in Vuesax documentation: https://lusaxweb.github.io/vuesax/components/dialog.html. Open and then close Dialog and you should see the error on the console.