### PR TITLE
Fix missing content of expandable-data table

### DIFF
--- a/src/components/vsTable/vsTr.vue
+++ b/src/components/vsTable/vsTr.vue
@@ -111,6 +111,7 @@ export default {
         tr.classList.add('tr-expandedx')
         let trx = Vue.extend(trExpand);
         let instance = new trx({parent: this, propsData: {colspan: this.colspan}});
+        instance.$slots.default = this.$slots.expand;
         instance.vm = instance.$mount();
         var newTR = document.createElement('tr').appendChild(instance.vm.$el);
         this.insertAfter(tr, newTR)


### PR DESCRIPTION
The content of expandable-data in table is not rendering
Reproduce: https://lusaxweb.github.io/vuesax/components/table.html#expandable-data 
#903 