### PR TITLE
Add span tag wrapping text for vsDialog component

### DIFF
--- a/src/functions/vsDialog/index.vue
+++ b/src/functions/vsDialog/index.vue
@@ -32,7 +32,7 @@
         </header>     <!-- // slots  -->
         <div class="vs-dialog-text">
           <slot/>
-          {{ text }}
+          <span>{{ text }}</span>
         </div>
         <!-- footer buttons -->
         <footer v-if="buttonsHidden?false:isPrompt||type=='confirm'">


### PR DESCRIPTION
This simply adds a span wrapper around the text passed as a property, allowing users to do things like line breaks `$vs.dialog({ text: "Some \n line." })` and properly formatting them with for example `white-space: pre-line` targeting in their css the `span` inside the `div` avoiding weird white spaces.