### PR TITLE
Fix vsUpload on iPhones

### DIFF
--- a/src/components/vsUpload/vsUpload.vue
+++ b/src/components/vsUpload/vsUpload.vue
@@ -298,9 +298,6 @@
             this.$emit('change', e.target.value, this.filesx)
           }
         }
-        const input = this.$refs.fileInput
-        input.type = 'text'
-        input.type = 'file'
 
         if (this.automatic) {
           this.upload('all')


### PR DESCRIPTION
These lines were causing the Uploading not working on iPhone on any browser (tested on Safari and Chrome).
Ref. https://github.com/lusaxweb/vuesax/issues/364