### PR TITLE
Fix the max height of vsCollapse on update

### DIFF
--- a/src/components/vsCollapse/vsCollapseItem.vue
+++ b/src/components/vsCollapse/vsCollapseItem.vue
@@ -97,6 +97,9 @@ export default {
       this.maxHeight = `${maxHeightx}px`
     }
   },
+  updated() {
+    this.changeHeight();
+  },
   beforeDestroy() {
     window.removeEventListener('resize', this.changeHeight);
   },


### PR DESCRIPTION
If vsCollapse content changes, the max height of it remains the same.