### PR TITLE
fix(sidebar): prevent extra space for sidebar item without an icon

### DIFF
--- a/src/components/vsSideBar/vsSidebarItem.vue
+++ b/src/components/vsSideBar/vsSidebarItem.vue
@@ -7,6 +7,7 @@
       v-if="to"
       :to="to">
       <vs-icon
+        v-if="icon"
         :icon-pack="iconPack"
         :icon="icon">
       </vs-icon>
@@ -16,6 +17,7 @@
       v-else
       :href="href">
       <vs-icon
+        v-if="icon"
         :icon-pack="iconPack"
         :icon="icon">
       </vs-icon>


### PR DESCRIPTION
Implements: #343 

Fixes an extra space caused by `<i>` element when an icon is not provided


### Before
<img width="624" alt="Screenshot 2021-10-31 at 18 23 50" src="https://user-images.githubusercontent.com/6773202/139593053-c2c1912b-c710-44f2-98ef-794b471d36a9.png">


### After
<img width="573" alt="Screenshot 2021-10-31 at 18 22 54" src="https://user-images.githubusercontent.com/6773202/139593057-73074e91-7f50-4928-8495-c0ffe0d0576a.png">
